### PR TITLE
[Feature] WeekPicker 로직 수정, 프로젝트 Warning 제거, NetworkDetector 추가

### DIFF
--- a/polaris-ios/polaris-ios.xcodeproj/project.pbxproj
+++ b/polaris-ios/polaris-ios.xcodeproj/project.pbxproj
@@ -369,6 +369,15 @@
 		CE8F71A0266BDA3500D4FDD7 /* TermsOfServiceView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE8F719E266BDA3500D4FDD7 /* TermsOfServiceView.xib */; };
 		CE8F71A4266BDA4D00D4FDD7 /* TermsOfServiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8F71A3266BDA4D00D4FDD7 /* TermsOfServiceView.swift */; };
 		CE8F71A5266BDA4D00D4FDD7 /* TermsOfServiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8F71A3266BDA4D00D4FDD7 /* TermsOfServiceView.swift */; };
+		CE99FC8D27B3DAF200E264A5 /* LastWeekOfMonthResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE99FC8C27B3DAF200E264A5 /* LastWeekOfMonthResponseModel.swift */; };
+		CE99FC8E27B3DAF200E264A5 /* LastWeekOfMonthResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE99FC8C27B3DAF200E264A5 /* LastWeekOfMonthResponseModel.swift */; };
+		CE99FC8F27B3DAF200E264A5 /* LastWeekOfMonthResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE99FC8C27B3DAF200E264A5 /* LastWeekOfMonthResponseModel.swift */; };
+		CE99FC9127B3DB8800E264A5 /* WeekPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE99FC9027B3DB8800E264A5 /* WeekPickerViewModel.swift */; };
+		CE99FC9227B3DB8800E264A5 /* WeekPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE99FC9027B3DB8800E264A5 /* WeekPickerViewModel.swift */; };
+		CE99FC9327B3DB8800E264A5 /* WeekPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE99FC9027B3DB8800E264A5 /* WeekPickerViewModel.swift */; };
+		CE99FC9D27B3EA0900E264A5 /* NickChangeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE99FC9C27B3EA0900E264A5 /* NickChangeViewModel.swift */; };
+		CE99FC9E27B3EA0900E264A5 /* NickChangeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE99FC9C27B3EA0900E264A5 /* NickChangeViewModel.swift */; };
+		CE99FC9F27B3EA0900E264A5 /* NickChangeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE99FC9C27B3EA0900E264A5 /* NickChangeViewModel.swift */; };
 		CEA3CFD726A85C4B00577DA4 /* ShootingComet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA3CFD626A85C4B00577DA4 /* ShootingComet.swift */; };
 		CEA3CFD826A85C6500577DA4 /* ShootingComet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA3CFD626A85C4B00577DA4 /* ShootingComet.swift */; };
 		CEA3CFD926A85C6500577DA4 /* ShootingComet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA3CFD626A85C4B00577DA4 /* ShootingComet.swift */; };
@@ -817,6 +826,9 @@
 		CE82B9AC2661DA11004B6D81 /* polaris-ios.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "polaris-ios.plist"; sourceTree = "<group>"; };
 		CE8F719E266BDA3500D4FDD7 /* TermsOfServiceView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TermsOfServiceView.xib; sourceTree = "<group>"; };
 		CE8F71A3266BDA4D00D4FDD7 /* TermsOfServiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfServiceView.swift; sourceTree = "<group>"; };
+		CE99FC8C27B3DAF200E264A5 /* LastWeekOfMonthResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastWeekOfMonthResponseModel.swift; sourceTree = "<group>"; };
+		CE99FC9027B3DB8800E264A5 /* WeekPickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekPickerViewModel.swift; sourceTree = "<group>"; };
+		CE99FC9C27B3EA0900E264A5 /* NickChangeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NickChangeViewModel.swift; sourceTree = "<group>"; };
 		CEA3CFD626A85C4B00577DA4 /* ShootingComet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShootingComet.swift; sourceTree = "<group>"; };
 		CEA3CFDB26A85E7600577DA4 /* PolarisWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolarisWebView.swift; sourceTree = "<group>"; };
 		CEA3CFDF26A868C000577DA4 /* Common.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Common.storyboard; sourceTree = "<group>"; };
@@ -1115,6 +1127,7 @@
 				EC7A3BFA2639537A00B59C98 /* MainTodoTVCViewModel.swift */,
 				CE573FFF267C8E9900665933 /* TodoViewModel.swift */,
 				EC8C907C277B3845008BE7CD /* LookBackViewModel.swift */,
+				CE99FC9027B3DB8800E264A5 /* WeekPickerViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1358,6 +1371,7 @@
 				CED6B6E726CAD10300D37647 /* SettingViewModel.swift */,
 				CEEBE6D126DA25A0004A54BA /* SignoutViewModel.swift */,
 				CE6CE93126E3654A00BDDB6C /* PolarisMakerViewModel.swift */,
+				CE99FC9C27B3EA0900E264A5 /* NickChangeViewModel.swift */,
 			);
 			path = Setting;
 			sourceTree = "<group>";
@@ -1495,6 +1509,7 @@
 				CED6B6DA26CAC1F900D37647 /* SuccessModel.swift */,
 				CE5C5B0027A0DE8400FDCE32 /* PolarisDate.swift */,
 				CEB9EA6F27AAAD7D0017F59B /* WeekResponseModel.swift */,
+				CE99FC8C27B3DAF200E264A5 /* LastWeekOfMonthResponseModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -2090,6 +2105,7 @@
 				ECA3C4682780254300970DF7 /* LookBackThirdViewController.swift in Sources */,
 				CEEE573D262A952100C39358 /* MockProviderFactory.swift in Sources */,
 				CEE574EC26307C4D00EA64B7 /* Array+.swift in Sources */,
+				CE99FC9D27B3EA0900E264A5 /* NickChangeViewModel.swift in Sources */,
 				ECB52B83278485A0000084CF /* RetrospectModel.swift in Sources */,
 				CEA5D98F2785A43C00A6D6DE /* RetrospectReportVC.swift in Sources */,
 				CEA3CFED26A8766700577DA4 /* ServiceTermKind.swift in Sources */,
@@ -2158,6 +2174,7 @@
 				EC0E354C277869E900B6B33F /* LookBackFirstStarCollectionViewCell.swift in Sources */,
 				ECA4947E262C670000CC2EB8 /* MainStarTVCViewModel.swift in Sources */,
 				CEA3CFF126A92B8900577DA4 /* TodoDayListModel.swift in Sources */,
+				CE99FC9127B3DB8800E264A5 /* WeekPickerViewModel.swift in Sources */,
 				CEB9EA5827A42A0D0017F59B /* RetrospectReportViewModelFormatter.swift in Sources */,
 				CE5C5B0927A0EB2000FDCE32 /* RetrospectViewModel.swift in Sources */,
 				CEA3CFD726A85C4B00577DA4 /* ShootingComet.swift in Sources */,
@@ -2169,6 +2186,7 @@
 				ECB639BA2781DFD4006C7D29 /* LookBackFourthCollectionViewCell.swift in Sources */,
 				CEC19AEB265103AA00DA747C /* DayTodoTableViewCell.swift in Sources */,
 				CEA44E6E267B3BE300A05650 /* TodoTableViewCell.swift in Sources */,
+				CE99FC8D27B3DAF200E264A5 /* LastWeekOfMonthResponseModel.swift in Sources */,
 				ECA494472629729000CC2EB8 /* TodoDateModel.swift in Sources */,
 				ECB5443726D3D0CA00FA4C50 /* UITextField+.swift in Sources */,
 				CE132141265A408F001E3C1F /* LoginViewModel.swift in Sources */,
@@ -2266,6 +2284,7 @@
 				ECA3C4692780254300970DF7 /* LookBackThirdViewController.swift in Sources */,
 				CE2953052687A0A500E21871 /* Array+.swift in Sources */,
 				CEA3CFEE26A8766700577DA4 /* ServiceTermKind.swift in Sources */,
+				CE99FC9E27B3EA0900E264A5 /* NickChangeViewModel.swift in Sources */,
 				EC81D50527853E59008608EA /* RetrospectModel.swift in Sources */,
 				CEA5D9902785A43C00A6D6DE /* RetrospectReportVC.swift in Sources */,
 				CEA3CFEA26A869D200577DA4 /* ObservableType+.swift in Sources */,
@@ -2334,6 +2353,7 @@
 				EC0E354D277869E900B6B33F /* LookBackFirstStarCollectionViewCell.swift in Sources */,
 				CE29532B2687A0A500E21871 /* MainStarTVCViewModel.swift in Sources */,
 				CEA3CFF226A92B8900577DA4 /* TodoDayListModel.swift in Sources */,
+				CE99FC9227B3DB8800E264A5 /* WeekPickerViewModel.swift in Sources */,
 				CEB9EA5927A42A0D0017F59B /* RetrospectReportViewModelFormatter.swift in Sources */,
 				CE5C5B0A27A0EB2000FDCE32 /* RetrospectViewModel.swift in Sources */,
 				CEA3CFD826A85C6500577DA4 /* ShootingComet.swift in Sources */,
@@ -2345,6 +2365,7 @@
 				ECB639BB2781DFD4006C7D29 /* LookBackFourthCollectionViewCell.swift in Sources */,
 				CE29532C2687A0A500E21871 /* DayTodoTableViewCell.swift in Sources */,
 				CE29532D2687A0A500E21871 /* TodoTableViewCell.swift in Sources */,
+				CE99FC8E27B3DAF200E264A5 /* LastWeekOfMonthResponseModel.swift in Sources */,
 				CE29532E2687A0A500E21871 /* TodoDateModel.swift in Sources */,
 				ECB5443826D3D0CA00FA4C50 /* UITextField+.swift in Sources */,
 				CE29532F2687A0A500E21871 /* LoginViewModel.swift in Sources */,
@@ -2442,6 +2463,7 @@
 				ECA3C46A2780254300970DF7 /* LookBackThirdViewController.swift in Sources */,
 				CE43D03426613D66003126F2 /* Array+.swift in Sources */,
 				CEA3CFEF26A8766700577DA4 /* ServiceTermKind.swift in Sources */,
+				CE99FC9F27B3EA0900E264A5 /* NickChangeViewModel.swift in Sources */,
 				EC81D50627853E59008608EA /* RetrospectModel.swift in Sources */,
 				CEA5D9912785A43C00A6D6DE /* RetrospectReportVC.swift in Sources */,
 				CEA3CFEB26A869D200577DA4 /* ObservableType+.swift in Sources */,
@@ -2510,6 +2532,7 @@
 				EC0E354E277869E900B6B33F /* LookBackFirstStarCollectionViewCell.swift in Sources */,
 				CE43D05226613D66003126F2 /* MainStarTVCViewModel.swift in Sources */,
 				CEA3CFF326A92B8900577DA4 /* TodoDayListModel.swift in Sources */,
+				CE99FC9327B3DB8800E264A5 /* WeekPickerViewModel.swift in Sources */,
 				CEB9EA5A27A42A0D0017F59B /* RetrospectReportViewModelFormatter.swift in Sources */,
 				CE5C5B0B27A0EB2000FDCE32 /* RetrospectViewModel.swift in Sources */,
 				CEA3CFD926A85C6500577DA4 /* ShootingComet.swift in Sources */,
@@ -2521,6 +2544,7 @@
 				ECB639BC2781DFD4006C7D29 /* LookBackFourthCollectionViewCell.swift in Sources */,
 				CE43D05326613D66003126F2 /* DayTodoTableViewCell.swift in Sources */,
 				CEA44E6F267B3BE300A05650 /* TodoTableViewCell.swift in Sources */,
+				CE99FC8F27B3DAF200E264A5 /* LastWeekOfMonthResponseModel.swift in Sources */,
 				CE43D05426613D66003126F2 /* TodoDateModel.swift in Sources */,
 				ECB5443926D3D0CA00FA4C50 /* UITextField+.swift in Sources */,
 				CE43D05526613D66003126F2 /* LoginViewModel.swift in Sources */,

--- a/polaris-ios/polaris-ios.xcodeproj/project.pbxproj
+++ b/polaris-ios/polaris-ios.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		343EE86C1BBB3A61832CF112 /* Pods_polaris_ios_Polaris_Beta.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B35230A1FF0651B0EB66A598 /* Pods_polaris_ios_Polaris_Beta.framework */; };
 		7EB0D09D416E16BB73D26E01 /* Pods_polaris_ios_Polaris_Alpha.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 19D1126DBB53127CC126B3AD /* Pods_polaris_ios_Polaris_Alpha.framework */; };
-		8924680670F33E94E942DFA3 /* Pods_polaris_ios_Polaris.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 62A763CE321F34C429250864 /* Pods_polaris_ios_Polaris.framework */; };
 		CE04A036262340D1007C98E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE04A035262340D1007C98E2 /* AppDelegate.swift */; };
 		CE04A038262340D1007C98E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE04A037262340D1007C98E2 /* SceneDelegate.swift */; };
 		CE04A03D262340D1007C98E2 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE04A03B262340D1007C98E2 /* Main.storyboard */; };
@@ -995,7 +994,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				CF563CFEB72C3AF1EB396E01 /* Pods_polaris_ios_Polaris.framework in Frameworks */,
-				8924680670F33E94E942DFA3 /* Pods_polaris_ios_Polaris.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1705,7 +1703,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1240;
-				LastUpgradeCheck = 1240;
+				LastUpgradeCheck = 1300;
 				TargetAttributes = {
 					CE04A031262340D1007C98E2 = {
 						CreatedOnToolsVersion = 12.4;
@@ -2160,7 +2158,6 @@
 				ECA49455262B0D0900CC2EB8 /* TodoDateTodayHeaderView.swift in Sources */,
 				CEE574E926307B4400EA64B7 /* AddTodoDayViewModel.swift in Sources */,
 				EC81D50427853CE9008608EA /* RetrospectResponseModel.swift in Sources */,
-				CEE574E926307B4400EA64B7 /* AddTodoDayViewModel.swift in Sources */,
 				CE04A06626234CEE007C98E2 /* UITableView+.swift in Sources */,
 				CE5C5B0D27A0EEDB00FDCE32 /* RetrospectValueListModel.swift in Sources */,
 				ECA494292628298B00CC2EB8 /* TodoModel.swift in Sources */,
@@ -2339,7 +2336,6 @@
 				CE2953222687A0A500E21871 /* TodoDateTodayHeaderView.swift in Sources */,
 				CE2953242687A0A500E21871 /* AddTodoDayViewModel.swift in Sources */,
 				EC81D50727853E5C008608EA /* RetrospectResponseModel.swift in Sources */,
-				CE2953242687A0A500E21871 /* AddTodoDayViewModel.swift in Sources */,
 				CE2953252687A0A500E21871 /* UITableView+.swift in Sources */,
 				CE5C5B0E27A0EEDB00FDCE32 /* RetrospectValueListModel.swift in Sources */,
 				CE2953262687A0A500E21871 /* TodoModel.swift in Sources */,
@@ -2518,7 +2514,6 @@
 				CE43D04A26613D66003126F2 /* TodoDateTodayHeaderView.swift in Sources */,
 				CE43D04C26613D66003126F2 /* AddTodoDayViewModel.swift in Sources */,
 				EC81D50827853E5C008608EA /* RetrospectResponseModel.swift in Sources */,
-				CE43D04C26613D66003126F2 /* AddTodoDayViewModel.swift in Sources */,
 				CE43D04D26613D66003126F2 /* UITableView+.swift in Sources */,
 				CE5C5B0F27A0EEDB00FDCE32 /* RetrospectValueListModel.swift in Sources */,
 				CE43D04E26613D66003126F2 /* TodoModel.swift in Sources */,

--- a/polaris-ios/polaris-ios.xcodeproj/project.pbxproj
+++ b/polaris-ios/polaris-ios.xcodeproj/project.pbxproj
@@ -447,6 +447,9 @@
 		CEAFD8AD27A90EAF00D390DB /* RetrospectFoundStarModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAFD8AC27A90EAF00D390DB /* RetrospectFoundStarModel.swift */; };
 		CEAFD8AE27A90EAF00D390DB /* RetrospectFoundStarModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAFD8AC27A90EAF00D390DB /* RetrospectFoundStarModel.swift */; };
 		CEAFD8AF27A90EAF00D390DB /* RetrospectFoundStarModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAFD8AC27A90EAF00D390DB /* RetrospectFoundStarModel.swift */; };
+		CEAFD8B127B7A02500D390DB /* NetworkDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAFD8B027B7A02500D390DB /* NetworkDetector.swift */; };
+		CEAFD8B227B7A02500D390DB /* NetworkDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAFD8B027B7A02500D390DB /* NetworkDetector.swift */; };
+		CEAFD8B327B7A02500D390DB /* NetworkDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAFD8B027B7A02500D390DB /* NetworkDetector.swift */; };
 		CEB9EA5827A42A0D0017F59B /* RetrospectReportViewModelFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9EA5727A42A0D0017F59B /* RetrospectReportViewModelFormatter.swift */; };
 		CEB9EA5927A42A0D0017F59B /* RetrospectReportViewModelFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9EA5727A42A0D0017F59B /* RetrospectReportViewModelFormatter.swift */; };
 		CEB9EA5A27A42A0D0017F59B /* RetrospectReportViewModelFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9EA5727A42A0D0017F59B /* RetrospectReportViewModelFormatter.swift */; };
@@ -854,6 +857,7 @@
 		CEAFD8A427A9051400D390DB /* RetrospectEmoticonModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectEmoticonModel.swift; sourceTree = "<group>"; };
 		CEAFD8A827A9057A00D390DB /* RetrospectEmoticonReasonModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectEmoticonReasonModel.swift; sourceTree = "<group>"; };
 		CEAFD8AC27A90EAF00D390DB /* RetrospectFoundStarModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectFoundStarModel.swift; sourceTree = "<group>"; };
+		CEAFD8B027B7A02500D390DB /* NetworkDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDetector.swift; sourceTree = "<group>"; };
 		CEB9EA5727A42A0D0017F59B /* RetrospectReportViewModelFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectReportViewModelFormatter.swift; sourceTree = "<group>"; };
 		CEB9EA5B27A42A710017F59B /* RetrospectFarStarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectFarStarViewModel.swift; sourceTree = "<group>"; };
 		CEB9EA5F27A42BC20017F59B /* RetrospectCloseStarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectCloseStarViewModel.swift; sourceTree = "<group>"; };
@@ -1208,6 +1212,7 @@
 				CEEE573B262A952000C39358 /* MockProviderFactory.swift */,
 				CEEE573C262A952100C39358 /* NetworkManager.swift */,
 				CE63050E2667E7BA00EBC1D4 /* NetworkInform.swift */,
+				CEAFD8B027B7A02500D390DB /* NetworkDetector.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -2116,6 +2121,7 @@
 				CE63050B2667E36E00EBC1D4 /* UserAPI.swift in Sources */,
 				CE04A06E2623595D007C98E2 /* StoryboardName.swift in Sources */,
 				CE57400E267C903700665933 /* JourneyTodoTableViewCell.swift in Sources */,
+				CEAFD8B127B7A02500D390DB /* NetworkDetector.swift in Sources */,
 				CEC48ED9262DCD2A00FD887F /* AddTodoDropdownViewModel.swift in Sources */,
 				ECC544CA279C01E70016D391 /* RetrospectEmotionTableViewCell.swift in Sources */,
 				ECC544AC279C013F0016D391 /* RetrospectEmotionReasonItemCell.swift in Sources */,
@@ -2294,6 +2300,7 @@
 				CE29530C2687A0A500E21871 /* StoryboardName.swift in Sources */,
 				CE29530D2687A0A500E21871 /* JourneyTodoTableViewCell.swift in Sources */,
 				CE29530E2687A0A500E21871 /* AddTodoDropdownViewModel.swift in Sources */,
+				CEAFD8B227B7A02500D390DB /* NetworkDetector.swift in Sources */,
 				CE29530F2687A0A500E21871 /* DefaultSession.swift in Sources */,
 				ECC544CB279C01E70016D391 /* RetrospectEmotionTableViewCell.swift in Sources */,
 				ECC544AD279C013F0016D391 /* RetrospectEmotionReasonItemCell.swift in Sources */,
@@ -2472,6 +2479,7 @@
 				CE43D03926613D66003126F2 /* StoryboardName.swift in Sources */,
 				CE57400F267C903700665933 /* JourneyTodoTableViewCell.swift in Sources */,
 				CE43D03A26613D66003126F2 /* AddTodoDropdownViewModel.swift in Sources */,
+				CEAFD8B327B7A02500D390DB /* NetworkDetector.swift in Sources */,
 				CE43D03B26613D66003126F2 /* DefaultSession.swift in Sources */,
 				ECC544CC279C01E70016D391 /* RetrospectEmotionTableViewCell.swift in Sources */,
 				ECC544AE279C013F0016D391 /* RetrospectEmotionReasonItemCell.swift in Sources */,

--- a/polaris-ios/polaris-ios.xcodeproj/xcshareddata/xcschemes/Polaris Alpha-DEV.xcscheme
+++ b/polaris-ios/polaris-ios.xcodeproj/xcshareddata/xcschemes/Polaris Alpha-DEV.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/polaris-ios/polaris-ios.xcodeproj/xcshareddata/xcschemes/Polaris Alpha-REAL.xcscheme
+++ b/polaris-ios/polaris-ios.xcodeproj/xcshareddata/xcschemes/Polaris Alpha-REAL.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/polaris-ios/polaris-ios.xcodeproj/xcshareddata/xcschemes/Polaris Beta-DEV.xcscheme
+++ b/polaris-ios/polaris-ios.xcodeproj/xcshareddata/xcschemes/Polaris Beta-DEV.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/polaris-ios/polaris-ios.xcodeproj/xcshareddata/xcschemes/Polaris Beta-REAL.xcscheme
+++ b/polaris-ios/polaris-ios.xcodeproj/xcshareddata/xcschemes/Polaris Beta-REAL.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/polaris-ios/polaris-ios.xcodeproj/xcshareddata/xcschemes/Polaris.xcscheme
+++ b/polaris-ios/polaris-ios.xcodeproj/xcshareddata/xcschemes/Polaris.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/polaris-ios/polaris-ios/Resources/Extension/Date+.swift
+++ b/polaris-ios/polaris-ios/Resources/Extension/Date+.swift
@@ -146,6 +146,11 @@ extension Date {
         let weeks = calendar.dateComponents([.weekOfMonth], from: first, to: last)
         return weeks.weekOfMonth! + 1
     }
+    
+    static func convertWeekNoToString(weekNo: Int) -> String? {
+        let weekDict = [1: "첫째주", 2: "둘째주", 3: "셋째주", 4: "넷째주", 5: "다섯째주"]
+        return weekDict[weekNo]
+    }
 
 }
 

--- a/polaris-ios/polaris-ios/Sources/AppDelegate.swift
+++ b/polaris-ios/polaris-ios/Sources/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        
+        NetworkDetector.shared.startMonitor()
         return true
     }
 

--- a/polaris-ios/polaris-ios/Sources/Model/LastWeekOfMonthResponseModel.swift
+++ b/polaris-ios/polaris-ios/Sources/Model/LastWeekOfMonthResponseModel.swift
@@ -1,0 +1,12 @@
+//
+//  LastWeekOfMonthResponseModel.swift
+//  polaris-ios
+//
+//  Created by Dongmin on 2022/02/09.
+//
+
+import Foundation
+
+struct LastWeekOfMonthResponseModel: Codable {
+    let weekNo: Int
+}

--- a/polaris-ios/polaris-ios/Sources/Model/LastWeekOfMonthResponseModel.swift
+++ b/polaris-ios/polaris-ios/Sources/Model/LastWeekOfMonthResponseModel.swift
@@ -8,5 +8,60 @@
 import Foundation
 
 struct LastWeekOfMonthResponseModel: Codable {
+    let data: [LastWeekOfMonthDataModel]
+}
+
+struct LastWeekOfMonthDataModel: Codable {
+    let year: Int
+    let jan: WeekNumberModel
+    let feb: WeekNumberModel
+    let mar: WeekNumberModel
+    let apr: WeekNumberModel
+    let may: WeekNumberModel
+    let jun: WeekNumberModel
+    let jul: WeekNumberModel
+    let aug: WeekNumberModel
+    let sep: WeekNumberModel
+    let oct: WeekNumberModel
+    let nov: WeekNumberModel
+    let dec: WeekNumberModel
+    
+    enum CodingKeys: String, CodingKey {
+        case year
+        case jan = "Jan"
+        case feb = "Feb"
+        case mar = "Mar"
+        case apr = "Apr"
+        case may = "May"
+        case jun = "Jun"
+        case jul = "Jul"
+        case aug = "Aug"
+        case sep = "Sep"
+        case oct = "Oct"
+        case nov = "Nov"
+        case dec = "Dec"
+    }
+    
+    func weekNo(ofMonth month: Int) -> Int? {
+        switch month {
+        case 1:  return self.jan.weekNo
+        case 2:  return self.feb.weekNo
+        case 3:  return self.mar.weekNo
+        case 4:  return self.apr.weekNo
+        case 5:  return self.may.weekNo
+        case 6:  return self.jun.weekNo
+        case 7:  return self.jul.weekNo
+        case 8:  return self.aug.weekNo
+        case 9:  return self.sep.weekNo
+        case 10: return self.oct.weekNo
+        case 11: return self.nov.weekNo
+        case 12: return self.dec.weekNo
+        default: return nil
+        }
+    }
+    
+}
+
+struct WeekNumberModel: Codable {
     let weekNo: Int
 }

--- a/polaris-ios/polaris-ios/Sources/Network/Moya/HomeAPI.swift
+++ b/polaris-ios/polaris-ios/Sources/Network/Moya/HomeAPI.swift
@@ -43,7 +43,7 @@ extension HomeAPI: TargetType {
     
     var task: Task {
         switch self {
-        case .getHomeBanner(let isSkipped):
+        case .getHomeBanner(_):
             return .requestParameters(parameters: [:], encoding: URLEncoding.queryString)
         }
     }

--- a/polaris-ios/polaris-ios/Sources/Network/Moya/JourneyAPI.swift
+++ b/polaris-ios/polaris-ios/Sources/Network/Moya/JourneyAPI.swift
@@ -10,7 +10,7 @@ import Moya
 
 enum JourneyAPI {
     case jouneyTitleList(date: String)
-    case createJourney(title: String, value1: String, value2: String? = nil, date: String)
+    case createJourney(title: String, value1: String, value2: String? = nil, date: PolarisDate)
     case getWeekJourney(year: Int, month: Int, weekNo: Int)
     case deleteJourney(idx: Int)
     case edittedJourney(idx: Int, title: String, value1: String, value: String? = nil)
@@ -51,7 +51,13 @@ extension JourneyAPI: TargetType {
         case .jouneyTitleList(let date):
             return .requestParameters(parameters: ["date": date], encoding: URLEncoding.default)
         case .createJourney(let title, let value1, let value2, let date):
-            var parameters: [String: Any] = ["title": title, "value1": value1, "date": date]
+            var parameters: [String: Any] = [
+                "title": title,
+                "value1": value1,
+                "year": date.year,
+                "month": date.month,
+                "weekNo": date.weekNo
+            ]
             if let value2 = value2 { parameters["value2"] = value2 }
             return .requestParameters(parameters: parameters, encoding: JSONEncoding.default)
         case .getWeekJourney(let year, let month, let weekNo):

--- a/polaris-ios/polaris-ios/Sources/Network/Moya/RetrospectAPI.swift
+++ b/polaris-ios/polaris-ios/Sources/Network/Moya/RetrospectAPI.swift
@@ -9,7 +9,7 @@ import Foundation
 import Moya
 
 enum RetrospectAPI {
-    case createLookBack(model: RetrospectModel)
+    case create(model: RetrospectModel)
     case listValues(date: PolarisDate? = nil)
     case getRetrospect(date: PolarisDate)
 }
@@ -22,7 +22,7 @@ extension RetrospectAPI: TargetType {
     
     var path: String {
         switch self {
-        case .createLookBack:   return "/retrospect/v0"
+        case .create:   return "/retrospect/v0"
         case .listValues:       return "/retrospect/v0/value"
         case .getRetrospect:    return "/retrospect/v0/"
         }
@@ -30,7 +30,7 @@ extension RetrospectAPI: TargetType {
     
     var method: Moya.Method {
         switch self {
-        case .createLookBack:   return .post
+        case .create:   return .post
         case .listValues:       fallthrough
         case .getRetrospect:    return .get
         }
@@ -42,25 +42,26 @@ extension RetrospectAPI: TargetType {
     
     var task: Task {
         switch self {
-        case .createLookBack(let model):
-            return .requestParameters(parameters: ["year": model.year,
-                                                   "month": model.month,
-                                                   "weekNo": model.weekNo,
-                                                   "value": [
-                                                        "y": model.value.y,
-                                                        "n": model.value.n,
-                                                        "health": model.value.health,
-                                                        "happy": model.value.happy,
-                                                        "challenge": model.value.challenge,
-                                                        "moderation": model.value.moderation,
-                                                        "emoticon": model.value.emoticon,
-                                                        "need": model.value.need
-                                                   ],
-                                                   "record1": model.record1,
-                                                   "record2": model.record2,
-                                                   "record3": model.record3
-                                                  ],
-                                      encoding: JSONEncoding.default)
+        case .create(let model):
+            var params = [String: Any]()
+            params["year"] = model.year
+            params["month"] = model.month
+            params["weekNo"] = model.weekNo
+            params["value"] = [
+                "y": model.value.y,
+                "n": model.value.n,
+                "health": model.value.health,
+                "happy": model.value.happy,
+                "challenge": model.value.challenge,
+                "moderation": model.value.moderation,
+                "emoticon": model.value.emoticon,
+                "need": model.value.need
+            ]
+            
+            if let record1 = model.record1 { params["record1"] = record1 }
+            if let record2 = model.record2 { params["record2"] = record2 }
+            if let record3 = model.record3 { params["record3"] = record3 }
+            return .requestParameters(parameters: params, encoding: JSONEncoding.default)
         case .listValues(let date):
             if let date = date {
                 let param: [String: String] = [

--- a/polaris-ios/polaris-ios/Sources/Network/Moya/WeekAPI.swift
+++ b/polaris-ios/polaris-ios/Sources/Network/Moya/WeekAPI.swift
@@ -10,7 +10,7 @@ import Moya
 
 enum WeekAPI {
     case getWeekNo(date: Date)
-    case lastWeekOfMonth(year: Int, month: Int)
+    case lastWeekOfMonth
 }
 
 extension WeekAPI: TargetType {
@@ -31,7 +31,7 @@ extension WeekAPI: TargetType {
     var method: Moya.Method {
         switch self {
         case .getWeekNo:        return .get
-        case .lastWeekOfMonth:  return .post
+        case .lastWeekOfMonth:  return .get
         }
     }
     
@@ -43,8 +43,8 @@ extension WeekAPI: TargetType {
         switch self {
         case .getWeekNo:
             return .requestPlain
-        case .lastWeekOfMonth(let year, let month):
-            return .requestParameters(parameters: ["year": year, "month": month], encoding: JSONEncoding.default)
+        case .lastWeekOfMonth:
+            return .requestPlain
         }
     }
     

--- a/polaris-ios/polaris-ios/Sources/Network/Moya/WeekAPI.swift
+++ b/polaris-ios/polaris-ios/Sources/Network/Moya/WeekAPI.swift
@@ -10,6 +10,7 @@ import Moya
 
 enum WeekAPI {
     case getWeekNo(date: Date)
+    case lastWeekOfMonth(year: Int, month: Int)
 }
 
 extension WeekAPI: TargetType {
@@ -22,12 +23,15 @@ extension WeekAPI: TargetType {
         switch self {
         case .getWeekNo(let date):
             return "/weekNo/v0/" + date.convertToString()
+        case .lastWeekOfMonth:
+            return "/weekNo/v0/lastWeekOfMonth"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .getWeekNo: return .get
+        case .getWeekNo:        return .get
+        case .lastWeekOfMonth:  return .post
         }
     }
     
@@ -39,6 +43,8 @@ extension WeekAPI: TargetType {
         switch self {
         case .getWeekNo:
             return .requestPlain
+        case .lastWeekOfMonth(let year, let month):
+            return .requestParameters(parameters: ["year": year, "month": month], encoding: JSONEncoding.default)
         }
     }
     

--- a/polaris-ios/polaris-ios/Sources/Network/NetworkDetector.swift
+++ b/polaris-ios/polaris-ios/Sources/Network/NetworkDetector.swift
@@ -1,0 +1,61 @@
+//
+//  NetworkDetector.swift
+//  polaris-ios
+//
+//  Created by Dongmin on 2022/02/12.
+//
+
+import Foundation
+import Network
+
+final class NetworkDetector {
+    
+    static let shared = NetworkDetector()
+    
+    var isConnected: Bool {
+        self.connectionType.isConnected
+    }
+    
+    func startMonitor() {
+        self.monitor.start(queue: .global())
+        self.monitor.pathUpdateHandler = { path in
+            var connectionType: NetworkConnection = NetworkConnection(rawValue: 0)
+            
+            if path.usesInterfaceType(.wifi) { connectionType.insert(.wifi) }
+            if path.usesInterfaceType(.cellular) { connectionType.insert(.cellular) }
+            if path.usesInterfaceType(.loopback) { connectionType.insert(.loopback) }
+            if path.usesInterfaceType(.wiredEthernet) { connectionType.insert(.ethernet) }
+            if path.usesInterfaceType(.other) { connectionType.insert(.unknown) }
+            self.connectionType = connectionType
+        }
+    }
+    
+    func stopMonitor() {
+        self.monitor.cancel()
+    }
+    
+    private init() {
+        self.monitor = NWPathMonitor()
+    }
+    
+    private(set) var connectionType: NetworkConnection = NetworkConnection(rawValue: 0)
+    
+    private let monitor: NWPathMonitor
+    
+}
+
+struct NetworkConnection: OptionSet {
+    
+    let rawValue: Int
+    
+    static let wifi = NetworkConnection(rawValue: 1 << 0)
+    static let cellular = NetworkConnection(rawValue: 1 << 1)
+    static let ethernet = NetworkConnection(rawValue: 1 << 2)
+    static let loopback = NetworkConnection(rawValue: 1 << 3)
+    static let unknown = NetworkConnection(rawValue: 1 << 4)
+    
+    var isConnected: Bool {
+        return self.isEmpty == false
+    }
+    
+}

--- a/polaris-ios/polaris-ios/Sources/Network/NetworkManager.swift
+++ b/polaris-ios/polaris-ios/Sources/Network/NetworkManager.swift
@@ -36,7 +36,7 @@ class NetworkManager {
                         single(.failure(error))
                     }
                 case .failure(let error):
-                    // TODO: 여기 전역적으로 네트워크 에러 띄우는 팝업창 코드 추가 예정
+                    PolarisToastManager.shared.showToast(with: "연결이 원활하지 않아요. 다시 시도해주세요.")
                     single(.failure(error))
                 }
             }

--- a/polaris-ios/polaris-ios/Sources/Network/NetworkManager.swift
+++ b/polaris-ios/polaris-ios/Sources/Network/NetworkManager.swift
@@ -36,7 +36,7 @@ class NetworkManager {
                         single(.failure(error))
                     }
                 case .failure(let error):
-                    PolarisToastManager.shared.showToast(with: "연결이 원활하지 않아요. 다시 시도해주세요.")
+                    self.handleNetworkDisconnectIfNeeded()
                     single(.failure(error))
                 }
             }
@@ -75,8 +75,10 @@ class NetworkManager {
         #endif
     }
     
-    private static func decodeIfNeeded() {
-        
+    private static func handleNetworkDisconnectIfNeeded() {
+        if NetworkDetector.shared.isConnected == false {
+            PolarisToastManager.shared.showToast(with: "연결이 원활하지 않아요. 다시 시도해주세요.")
+        }
     }
     
 }

--- a/polaris-ios/polaris-ios/Sources/Repository/WeekRepository.swift
+++ b/polaris-ios/polaris-ios/Sources/Repository/WeekRepository.swift
@@ -10,7 +10,7 @@ import Foundation
 
 protocol WeekRepository {
     func fetchWeekNo(ofDate date: Date) -> Observable<Int>
-    func fetchLastWeekOfMonth(year: Int, month: Int) -> Observable<Int>
+    func fetchLastWeekOfMonth() -> Observable<[LastWeekOfMonthDataModel]>
 }
 
 final class WeekRepositoryImpl: WeekRepository {
@@ -24,11 +24,11 @@ final class WeekRepositoryImpl: WeekRepository {
             .asObservable()
     }
     
-    func fetchLastWeekOfMonth(year: Int, month: Int) -> Observable<Int> {
-        let weekAPI = WeekAPI.lastWeekOfMonth(year: year, month: month)
+    func fetchLastWeekOfMonth() -> Observable<[LastWeekOfMonthDataModel]> {
+        let weekAPI = WeekAPI.lastWeekOfMonth
         return NetworkManager.request(apiType: weekAPI)
             .map { (lastWeekModel: LastWeekOfMonthResponseModel) in
-                return lastWeekModel.weekNo
+                return lastWeekModel.data
             }
             .asObservable()
     }

--- a/polaris-ios/polaris-ios/Sources/Repository/WeekRepository.swift
+++ b/polaris-ios/polaris-ios/Sources/Repository/WeekRepository.swift
@@ -10,6 +10,7 @@ import Foundation
 
 protocol WeekRepository {
     func fetchWeekNo(ofDate date: Date) -> Observable<Int>
+    func fetchLastWeekOfMonth(year: Int, month: Int) -> Observable<Int>
 }
 
 final class WeekRepositoryImpl: WeekRepository {
@@ -19,6 +20,15 @@ final class WeekRepositoryImpl: WeekRepository {
         return NetworkManager.request(apiType: weekAPI)
             .map { (weekModel: WeekResponseModel) in
                 return weekModel.weekNo
+            }
+            .asObservable()
+    }
+    
+    func fetchLastWeekOfMonth(year: Int, month: Int) -> Observable<Int> {
+        let weekAPI = WeekAPI.lastWeekOfMonth(year: year, month: month)
+        return NetworkManager.request(apiType: weekAPI)
+            .map { (lastWeekModel: LastWeekOfMonthResponseModel) in
+                return lastWeekModel.weekNo
             }
             .asObservable()
     }

--- a/polaris-ios/polaris-ios/Sources/Storyboard/Intro.storyboard
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/Intro.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -265,7 +265,7 @@
                                 </constraints>
                             </view>
                             <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="4" translatesAutoresizingMaskIntoConstraints="NO" id="ELG-xa-jXd">
-                                <rect key="frame" x="-15" y="101" width="129.66666666666666" height="7"/>
+                                <rect key="frame" x="-15" y="101" width="172.66666666666666" height="7"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="7" id="4A3-04-CnI"/>
                                 </constraints>

--- a/polaris-ios/polaris-ios/Sources/Storyboard/LookBack.storyboard
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/LookBack.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -28,8 +28,8 @@
                                     <constraint firstAttribute="width" constant="48" id="nXG-cG-khY"/>
                                     <constraint firstAttribute="height" constant="48" id="tuu-G1-1hH"/>
                                 </constraints>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" image="btnCloseLookBack" title=" "/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title=" " image="btnCloseLookBack"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="color" keyPath="imageTintColor">
                                         <color key="value" name="mainText"/>
@@ -45,8 +45,8 @@
                                     <constraint firstAttribute="width" constant="48" id="9cS-0p-gGd"/>
                                     <constraint firstAttribute="height" constant="48" id="Xts-lv-5We"/>
                                 </constraints>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" image="btnBackLookBack" title=" "/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title=" " image="btnBackLookBack"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="color" keyPath="imageTintColor">
                                         <color key="value" name="mainText"/>
@@ -57,7 +57,7 @@
                                 </connections>
                             </button>
                             <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" numberOfPages="5" translatesAutoresizingMaskIntoConstraints="NO" id="Hzc-yZ-bnJ">
-                                <rect key="frame" x="23" y="121" width="146.66666666666666" height="7"/>
+                                <rect key="frame" x="23" y="121" width="189.66666666666666" height="7"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="7" id="zfA-Oq-ZvE"/>
                                 </constraints>
@@ -154,8 +154,8 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="56" id="4Kb-Y8-L19"/>
                                 </constraints>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title=" "/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title=" "/>
                                 <connections>
                                     <action selector="buttonAction:" destination="eDE-mJ-dtK" eventType="touchUpInside" id="Kjb-Ak-vQZ"/>
                                 </connections>
@@ -243,8 +243,8 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="56" id="jgw-Ss-Ygk"/>
                                 </constraints>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title=""/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title=""/>
                                 <connections>
                                     <action selector="buttonAction:" destination="RQS-8z-Ry3" eventType="touchUpInside" id="rKg-Ss-thp"/>
                                 </connections>
@@ -312,8 +312,8 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="56" id="pYB-C5-9Ck"/>
                                 </constraints>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain"/>
                                 <connections>
                                     <action selector="nextButtonAction:" destination="qF5-0c-ubo" eventType="touchUpInside" id="WJn-l5-Xhg"/>
                                 </connections>
@@ -400,8 +400,8 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="56" id="yhF-0c-j1G"/>
                                 </constraints>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title=""/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title=""/>
                                 <connections>
                                     <action selector="nextButtonAction:" destination="879-xA-Cq2" eventType="touchUpInside" id="wVe-Uc-YSk"/>
                                 </connections>
@@ -466,8 +466,8 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="56" id="hGs-SI-6Ba"/>
                                 </constraints>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain"/>
                                 <connections>
                                     <action selector="nextButtonAction:" destination="OPw-kr-bJE" eventType="touchUpInside" id="9lo-nP-CuM"/>
                                 </connections>
@@ -493,8 +493,8 @@
                                     <constraint firstAttribute="width" constant="100" id="cvo-wk-9X4"/>
                                 </constraints>
                                 <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain"/>
                                 <connections>
                                     <action selector="skipButtonAction:" destination="OPw-kr-bJE" eventType="touchUpInside" id="cfQ-sk-whD"/>
                                 </connections>
@@ -599,8 +599,8 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="56" id="bYq-i7-uUh"/>
                                 </constraints>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title=""/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title=""/>
                                 <connections>
                                     <action selector="buttonAction:" destination="vAy-hd-d70" eventType="touchUpInside" id="waT-qr-Sjz"/>
                                 </connections>

--- a/polaris-ios/polaris-ios/Sources/Storyboard/Retrospect.storyboard
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/Retrospect.storyboard
@@ -33,8 +33,8 @@
                                             <constraint firstAttribute="height" constant="48" id="eHA-wx-cK3"/>
                                             <constraint firstAttribute="width" constant="48" id="hch-5A-osS"/>
                                         </constraints>
-                                        <state key="normal" title="Button"/>
-                                        <buttonConfiguration key="configuration" style="plain" image="btnBackLookBack" title=""/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="" image="btnBackLookBack"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="color" keyPath="imageTintColor">
                                                 <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -53,8 +53,8 @@
                                             <constraint firstAttribute="width" constant="48" id="Kb6-m8-MaV"/>
                                             <constraint firstAttribute="height" constant="48" id="ncp-zf-7SN"/>
                                         </constraints>
-                                        <state key="normal" title="Button"/>
-                                        <buttonConfiguration key="configuration" style="plain" image="btnCalendar" title=""/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="" image="btnCalendar"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="color" keyPath="imageTintColor">
                                                 <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -108,8 +108,8 @@
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Vo-pM-3K3">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
-                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="5kO-n1-43n">
-                                        <rect key="frame" x="197" y="458" width="20" height="20"/>
+                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="5kO-n1-43n">
+                                        <rect key="frame" x="197" y="438" width="20" height="20"/>
                                     </activityIndicatorView>
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/polaris-ios/polaris-ios/Sources/Storyboard/Retrospect.storyboard
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/Retrospect.storyboard
@@ -73,6 +73,38 @@
                                     <constraint firstAttribute="trailing" secondItem="TNg-kG-jMA" secondAttribute="trailing" constant="10" id="kXA-vm-WH9"/>
                                 </constraints>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X3G-hq-bfh">
+                                <rect key="frame" x="0.0" y="321" width="414" height="575"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이 주에는 회고를 하지 않았어요!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JL4-OJ-Oxy">
+                                        <rect key="frame" x="94" y="277" width="226" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="JL4-OJ-Oxy" firstAttribute="centerY" secondItem="X3G-hq-bfh" secondAttribute="centerY" id="Zh2-29-fUk"/>
+                                    <constraint firstItem="JL4-OJ-Oxy" firstAttribute="centerX" secondItem="X3G-hq-bfh" secondAttribute="centerX" id="rIa-4z-8ck"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hg8-5h-MHJ">
+                                <rect key="frame" x="0.0" y="104" width="414" height="792"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이 주에는 할일을 등록하지 않았어요!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Lg-st-fKL">
+                                        <rect key="frame" x="78.5" y="385.5" width="257" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="9Lg-st-fKL" firstAttribute="centerX" secondItem="hg8-5h-MHJ" secondAttribute="centerX" id="Vf4-3L-XVr"/>
+                                    <constraint firstItem="9Lg-st-fKL" firstAttribute="centerY" secondItem="hg8-5h-MHJ" secondAttribute="centerY" id="i7l-Fg-lYV"/>
+                                </constraints>
+                            </view>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Vo-pM-3K3">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
@@ -90,14 +122,22 @@
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="hg8-5h-MHJ" secondAttribute="trailing" id="2bZ-Po-lUe"/>
                             <constraint firstItem="bxW-Pa-r2m" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="5Ze-iH-XEi"/>
+                            <constraint firstAttribute="bottom" secondItem="X3G-hq-bfh" secondAttribute="bottom" id="6oy-Ns-jRW"/>
                             <constraint firstItem="73E-EW-tIY" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="Klf-af-XcU"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="X3G-hq-bfh" secondAttribute="trailing" id="LoN-VE-afg"/>
+                            <constraint firstAttribute="bottom" secondItem="hg8-5h-MHJ" secondAttribute="bottom" id="P8Q-c4-Jbu"/>
+                            <constraint firstItem="X3G-hq-bfh" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="Q37-Fv-Bvt"/>
                             <constraint firstItem="5Vo-pM-3K3" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="R2c-gY-Zgc"/>
                             <constraint firstAttribute="bottom" secondItem="5Vo-pM-3K3" secondAttribute="bottom" id="UAA-4p-ic2"/>
+                            <constraint firstItem="hg8-5h-MHJ" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="WnE-Zg-1mo"/>
                             <constraint firstItem="0En-Nc-wNE" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="XEs-XK-6ZF"/>
                             <constraint firstItem="73E-EW-tIY" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="Xss-Qn-Ele"/>
                             <constraint firstItem="5Vo-pM-3K3" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="Y4c-o4-8OH"/>
+                            <constraint firstItem="X3G-hq-bfh" firstAttribute="top" secondItem="0En-Nc-wNE" secondAttribute="bottom" constant="217" id="cjy-8F-w6F"/>
                             <constraint firstAttribute="bottom" secondItem="73E-EW-tIY" secondAttribute="bottom" id="g2x-pm-Jjj"/>
+                            <constraint firstItem="hg8-5h-MHJ" firstAttribute="top" secondItem="0En-Nc-wNE" secondAttribute="bottom" id="gEq-nP-hZ3"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="bxW-Pa-r2m" secondAttribute="trailing" id="mQA-na-583"/>
                             <constraint firstItem="0En-Nc-wNE" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="sIN-Iu-wN9"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="0En-Nc-wNE" secondAttribute="trailing" id="t4k-eg-YUy"/>
@@ -113,7 +153,9 @@
                         <outlet property="dateLabel" destination="Yt5-AQ-e1K" id="dbV-kr-b6P"/>
                         <outlet property="indicatorContainerView" destination="5Vo-pM-3K3" id="p6e-61-LdR"/>
                         <outlet property="indicatorView" destination="5kO-n1-43n" id="HY0-qL-Lzd"/>
+                        <outlet property="retrospectEmptyView" destination="X3G-hq-bfh" id="klM-k8-6St"/>
                         <outlet property="tableView" destination="bxW-Pa-r2m" id="rZ2-iQ-caO"/>
+                        <outlet property="todoEmptyView" destination="hg8-5h-MHJ" id="GDk-av-PTO"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/polaris-ios/polaris-ios/Sources/Storyboard/Retrospect.storyboard
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/Retrospect.storyboard
@@ -41,8 +41,8 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </button>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2021년 4월 첫째주" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yt5-AQ-e1K">
-                                        <rect key="frame" x="137" y="19.5" width="140" height="21"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yt5-AQ-e1K">
+                                        <rect key="frame" x="207" y="30" width="0.0" height="0.0"/>
                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>

--- a/polaris-ios/polaris-ios/Sources/Storyboard/Setting.storyboard
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/Setting.storyboard
@@ -392,7 +392,7 @@
                                     <action selector="changeButtonAction:" destination="cVb-GK-eAb" eventType="touchUpInside" id="Gyy-dQ-Z3Q"/>
                                 </connections>
                             </button>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Ew-gH-f36">
+                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Ew-gH-f36">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                                 <subviews>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="eEq-oC-fE3">
@@ -428,7 +428,6 @@
                     </view>
                     <connections>
                         <outlet property="backButton" destination="Luh-CH-gvl" id="zYK-eU-G54"/>
-                        <outlet property="dimView" destination="0Ew-gH-f36" id="Esr-Mm-eiV"/>
                         <outlet property="indicatorContainerView" destination="0Ew-gH-f36" id="vo9-nq-7gJ"/>
                         <outlet property="indicatorView" destination="eEq-oC-fE3" id="zWu-9i-MSj"/>
                         <outlet property="nickTextField" destination="6EQ-04-dEf" id="cOV-iy-Hme"/>

--- a/polaris-ios/polaris-ios/Sources/Storyboard/Setting.storyboard
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/Setting.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -302,7 +303,7 @@
                                 </constraints>
                             </view>
                             <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="4" translatesAutoresizingMaskIntoConstraints="NO" id="oci-kn-Wes">
-                                <rect key="frame" x="118" y="745" width="139" height="27"/>
+                                <rect key="frame" x="101.33333333333333" y="747" width="172.66666666666669" height="25"/>
                                 <color key="currentPageIndicatorTintColor" name="mainSky"/>
                             </pageControl>
                         </subviews>
@@ -391,11 +392,25 @@
                                     <action selector="changeButtonAction:" destination="cVb-GK-eAb" eventType="touchUpInside" id="Gyy-dQ-Z3Q"/>
                                 </connections>
                             </button>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Ew-gH-f36">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                                <subviews>
+                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="eEq-oC-fE3">
+                                        <rect key="frame" x="177.66666666666666" y="396" width="20" height="20"/>
+                                    </activityIndicatorView>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="eEq-oC-fE3" firstAttribute="centerX" secondItem="0Ew-gH-f36" secondAttribute="centerX" id="ejl-4T-WLE"/>
+                                    <constraint firstItem="eEq-oC-fE3" firstAttribute="centerY" secondItem="0Ew-gH-f36" secondAttribute="centerY" id="hvT-bG-N2H"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="WhI-7M-bdz"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="96a-Wv-xdO" firstAttribute="leading" secondItem="WhI-7M-bdz" secondAttribute="leading" constant="24" id="0ar-8S-ucC"/>
+                            <constraint firstItem="0Ew-gH-f36" firstAttribute="trailing" secondItem="WhI-7M-bdz" secondAttribute="trailing" id="3yy-gt-xok"/>
                             <constraint firstItem="WhI-7M-bdz" firstAttribute="trailing" secondItem="6EQ-04-dEf" secondAttribute="trailing" constant="23" id="7Ck-7X-40A"/>
                             <constraint firstAttribute="bottom" secondItem="M5h-yR-jjg" secondAttribute="bottom" constant="37" id="CkC-Mm-E9F"/>
                             <constraint firstItem="6EQ-04-dEf" firstAttribute="top" secondItem="96a-Wv-xdO" secondAttribute="bottom" constant="65" id="EmD-LB-HNN"/>
@@ -404,19 +419,25 @@
                             <constraint firstItem="96a-Wv-xdO" firstAttribute="top" secondItem="Luh-CH-gvl" secondAttribute="bottom" constant="3" id="N1M-H9-zTN"/>
                             <constraint firstItem="Luh-CH-gvl" firstAttribute="top" secondItem="RIU-Np-HM0" secondAttribute="top" constant="56" id="QMA-IF-FLf"/>
                             <constraint firstItem="M5h-yR-jjg" firstAttribute="width" secondItem="M5h-yR-jjg" secondAttribute="height" multiplier="184:27" id="Qhm-RV-82Q"/>
+                            <constraint firstItem="0Ew-gH-f36" firstAttribute="leading" secondItem="WhI-7M-bdz" secondAttribute="leading" id="VnW-4n-64h"/>
+                            <constraint firstAttribute="bottom" secondItem="0Ew-gH-f36" secondAttribute="bottom" id="cKD-5C-ZmH"/>
                             <constraint firstItem="M5h-yR-jjg" firstAttribute="leading" secondItem="WhI-7M-bdz" secondAttribute="leading" constant="23" id="ekc-Gh-g4Z"/>
                             <constraint firstItem="WhI-7M-bdz" firstAttribute="trailing" secondItem="M5h-yR-jjg" secondAttribute="trailing" constant="23" id="reu-na-WQ2"/>
+                            <constraint firstItem="0Ew-gH-f36" firstAttribute="top" secondItem="RIU-Np-HM0" secondAttribute="top" id="wTt-C7-UxP"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="backButton" destination="Luh-CH-gvl" id="zYK-eU-G54"/>
+                        <outlet property="dimView" destination="0Ew-gH-f36" id="Esr-Mm-eiV"/>
+                        <outlet property="indicatorContainerView" destination="0Ew-gH-f36" id="vo9-nq-7gJ"/>
+                        <outlet property="indicatorView" destination="eEq-oC-fE3" id="zWu-9i-MSj"/>
                         <outlet property="nickTextField" destination="6EQ-04-dEf" id="cOV-iy-Hme"/>
                         <outlet property="titleLabel" destination="96a-Wv-xdO" id="wPi-EL-4qP"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dtR-78-bxL" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="901" y="131"/>
+            <point key="canvasLocation" x="900" y="130.78817733990149"/>
         </scene>
     </scenes>
     <resources>

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoDayTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoDayTableViewCell.swift
@@ -25,7 +25,6 @@ class AddTodoDayTableViewCell: AddTodoTableViewCell {
     // MARK: - Life Cycle
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
         self.registerCell()
         self.layoutColletionView()
         self.bindCollectionView()

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/DayTodoTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/DayTodoTableViewCell.swift
@@ -94,7 +94,7 @@ final class DayTodoTableViewCell: TodoCategoryCell {
         self.editButton.rx.tap.subscribe(onNext: { [weak self] in
             guard let self = self                else { return }
             guard let todoModel = self.todoModel else { return }
-            guard let indexPath = self.indexPath else { return }
+            guard self.indexPath != nil          else { return }
             
             self.layoutForExpaned(isExpaned: false, animated: true)
             self.delegate?.todoCategoryCell(self, category: .day, isExpanded: false, forTodo: todoModel)
@@ -104,7 +104,7 @@ final class DayTodoTableViewCell: TodoCategoryCell {
         self.deleteButton.rx.tap.subscribe(onNext: { [weak self] in
             guard let self = self                else { return }
             guard let todoModel = self.todoModel else { return }
-            guard let indexPath = self.indexPath else { return }
+            guard self.indexPath != nil          else { return }
             
             self.layoutForExpaned(isExpaned: false, animated: true)
             self.delegate?.todoCategoryCell(self, category: .day, isExpanded: false, forTodo: todoModel)

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/JourneyTodoTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/JourneyTodoTableViewCell.swift
@@ -64,7 +64,7 @@ class JourneyTodoTableViewCell: TodoCategoryCell {
         self.editButton.rx.tap.observeOnMain(onNext: { [weak self] in
             guard let self = self                else { return }
             guard let todoModel = self.todoModel else { return }
-            guard let indexPath = self.indexPath else { return }
+            guard self.indexPath != nil          else { return }
             
             self.layoutForExpaned(isExpaned: false, animated: true)
             self._delegate?.journeyTodoTableViewCell(self, didTapEdit: todoModel)
@@ -74,7 +74,7 @@ class JourneyTodoTableViewCell: TodoCategoryCell {
         self.deleteButton.rx.tap.observeOnMain(onNext: { [weak self] in
             guard let self = self                else { return }
             guard let todoModel = self.todoModel else { return }
-            guard let indexPath = self.indexPath else { return }
+            guard self.indexPath != nil          else { return }
             
             self.layoutForExpaned(isExpaned: false, animated: true)
             self._delegate?.journeyTodoTableViewCell(self, didTapDelete: todoModel)

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/LookBackFifthTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/LookBackFifthTableViewCell.swift
@@ -53,7 +53,7 @@ class LookBackFifthTableViewCell: UITableViewCell {
     }
     
     @IBAction func xButtonAction(_ sender: Any) {
-        guard let index = self.index,
+        guard self.index != nil,
               let removeReason = self.label.text
         else { return }
         self.viewModel?.removeFifthvcReason(removeReason: removeReason)

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/MainSceneTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/MainSceneTableViewCell.swift
@@ -51,7 +51,7 @@ final class MainSceneTableViewCell: MainTableViewCell {
     
     override static var cellHeight: CGFloat { return DeviceInfo.screenHeight }
     
-    private var dateInfo = DateInfo(year: Date.currentYear, month: Date.currentMonth, weekNo: Date.currentWeekNoOfMonth)
+    private var dateInfo = PolarisDate(year: Date.currentYear, month: Date.currentMonth, weekNo: Date.currentWeekNoOfMonth)
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -427,10 +427,10 @@ extension MainSceneTableViewCell: LookBackCloseDelegate {
 
 extension MainSceneTableViewCell: WeekPickerDelegate {
     
-    func apply(year: Int, month: Int, weekNo: Int, weekText: String) {
-        let dateInfo = DateInfo(year: year, month: month, weekNo: weekNo)
-        self.weekLabel.text = weekText
-        self.viewModel.updateDateInfo(dateInfo)
+    func weekPickerViewController(_ viewController: WeekPickerVC, didSelectedDate date: PolarisDate) {
+        guard let weekNoText = Date.convertWeekNoToString(weekNo: date.weekNo) else { return }
+        self.weekLabel.text = "\(date.year)년 " + "\(date.month)월 " + weekNoText
+        self.viewModel.updateDateInfo(date)
     }
     
 }

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/MainSceneTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/MainSceneTableViewCell.swift
@@ -253,7 +253,7 @@ final class MainSceneTableViewCell: MainTableViewCell {
         
         let cometImgNames = [ImageName.imgShootingstar,ImageName.imgShootingstar2]
         
-        //        0: small, 1 : big
+        // 0: small, 1 : big
         let cometSize = Int.random(in: 0...1)
         let comet = UIImageView(image: UIImage(named: cometImgNames[cometSize]))
         

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/MainSceneTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/MainSceneTableViewCell.swift
@@ -50,7 +50,6 @@ final class MainSceneTableViewCell: MainTableViewCell {
     private let starTVCHeight = 212*(DeviceInfo.screenHeight/812.0)
     
     override static var cellHeight: CGFloat { return DeviceInfo.screenHeight }
-    private let weekDict = [1:"첫째주",2:"둘째주",3:"셋째주",4:"넷째주",5:"다섯째주"]
     
     private var dateInfo = DateInfo(year: Date.currentYear, month: Date.currentMonth, weekNo: Date.currentWeekNoOfMonth)
 
@@ -93,7 +92,7 @@ final class MainSceneTableViewCell: MainTableViewCell {
         self.weekContainView.makeRounded(cornerRadius: 9)
         self.weekLabel.font = UIFont.systemFont(ofSize: 13,weight: .bold)
         self.weekLabel.addCharacterSpacing(kernValue: -0.39)
-        if let weekText = self.weekDict[Date.currentWeekNoOfMonth] {
+        if let weekText = Date.convertWeekNoToString(weekNo: Date.currentWeekNoOfMonth) {
             self.weekLabel.text = String(Date.currentYear)+"년 "+String(Date.currentMonth)+"월"+weekText
         }
         self.weekLabel.textColor = .white

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/MainStarTVC.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/MainStarTVC.swift
@@ -48,8 +48,6 @@ class MainStarTVC: UITableViewCell {
     }
     
     func bindViewModel(){
-        let identifier = String(describing: MainStarCVC.self)
-        
         self.tvcViewModel.starListRelay.bind(to: starCV.rx.items) { collectionView, index, item in
             let identifier = String(describing: MainStarCVC.self)
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: identifier, for: IndexPath(item: index, section: 0)) as! MainStarCVC

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectCloseStarTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectCloseStarTableViewCell.swift
@@ -11,7 +11,9 @@ import UIKit
 
 class RetrospectCloseStarTableViewCell: RetrospectReportCell {
     
-    override class var cellHeight: CGFloat { 160 + 24 }
+    override class var cellHeight: CGFloat {
+        RetrospectLayoutGuide.closeStarCellHeight
+    }
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -21,7 +23,7 @@ class RetrospectCloseStarTableViewCell: RetrospectReportCell {
     
     override func configure(presentable: RetrospectReportPresentable) {
         super.configure(presentable: presentable)
-        // TODO: - 서버 데이터 반영 필요
+        self.collectionView.reloadData()
     }
     
     private func setupCollectionView() {
@@ -40,6 +42,10 @@ class RetrospectCloseStarTableViewCell: RetrospectReportCell {
         }
     }
     
+    private var closeStarPresentable: RetrospectCloseStarsModel? {
+        self.presentable as? RetrospectCloseStarsModel
+    }
+    
     private let disposeBag = DisposeBag()
     
     @IBOutlet private weak var collectionView: UICollectionView!
@@ -49,21 +55,19 @@ class RetrospectCloseStarTableViewCell: RetrospectReportCell {
 extension RetrospectCloseStarTableViewCell: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        // TODO: - 서버 데이터 반영 필요
-        return 5
+        self.closeStarPresentable?.closeStars.count ?? 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(cell: RetrospectJourneyItemCell.self, forIndexPath: indexPath)
+        let closeStars = self.closeStarPresentable?.closeStars
         
         guard let itemCell = cell else { return UICollectionViewCell() }
-        itemCell.configure(journey: .control)
+        guard let journey = closeStars?[safe: indexPath.row] else { return UICollectionViewCell() }
+        itemCell.configure(journey: journey)
         return itemCell
     }
     
 }
 
-extension RetrospectCloseStarTableViewCell: UICollectionViewDelegate {
-    
-    
-}
+extension RetrospectCloseStarTableViewCell: UICollectionViewDelegate {}

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectCloseStarTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectCloseStarTableViewCell.swift
@@ -30,6 +30,7 @@ class RetrospectCloseStarTableViewCell: RetrospectReportCell {
         self.collectionView.registerCell(cell: RetrospectJourneyItemCell.self)
         self.collectionView.dataSource = self
         self.collectionView.delegate = self
+        self.collectionView.allowsSelection = false
         self.collectionView.showsHorizontalScrollIndicator = false
     }
     

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectCloseStarTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectCloseStarTableViewCell.swift
@@ -30,12 +30,13 @@ class RetrospectCloseStarTableViewCell: RetrospectReportCell {
         self.collectionView.registerCell(cell: RetrospectJourneyItemCell.self)
         self.collectionView.dataSource = self
         self.collectionView.delegate = self
+        self.collectionView.showsHorizontalScrollIndicator = false
     }
     
     private func layoutCollectionView() {
         if let collectionViewLayout = self.collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
             collectionViewLayout.scrollDirection = .horizontal
-            collectionViewLayout.itemSize = CGSize(width: 48, height: 84)
+            collectionViewLayout.itemSize = RetrospectJourneyItemCell.cellSize
             collectionViewLayout.minimumLineSpacing = 20
             collectionViewLayout.minimumInteritemSpacing = 0
             collectionViewLayout.sectionInset = UIEdgeInsets(top: 0, left: 27, bottom: 0, right: 27)
@@ -45,8 +46,6 @@ class RetrospectCloseStarTableViewCell: RetrospectReportCell {
     private var closeStarPresentable: RetrospectCloseStarsModel? {
         self.presentable as? RetrospectCloseStarsModel
     }
-    
-    private let disposeBag = DisposeBag()
     
     @IBOutlet private weak var collectionView: UICollectionView!
     

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectEmotionReasonTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectEmotionReasonTableViewCell.swift
@@ -9,7 +9,9 @@ import UIKit
 
 class RetrospectEmotionReasonTableViewCell: RetrospectReportCell {
     
-    override class var cellHeight: CGFloat { return 30 + 392 }
+    override class var cellHeight: CGFloat {
+        RetrospectLayoutGuide.emotionReasonCellHeight
+    }
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectEmotionReasonTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectEmotionReasonTableViewCell.swift
@@ -21,7 +21,7 @@ class RetrospectEmotionReasonTableViewCell: RetrospectReportCell {
     
     override func configure(presentable: RetrospectReportPresentable) {
         super.configure(presentable: presentable)
-        // TODO: - 서버 데이터 반영되고 필요
+        self.collectionView.reloadData()
     }
     
     private func layoutCollectionView() {
@@ -44,6 +44,10 @@ class RetrospectEmotionReasonTableViewCell: RetrospectReportCell {
         self.collectionView.allowsSelection = false
     }
     
+    private var emotionReasonPresentable: RetrospectEmoticonReasonModel? {
+        self.presentable as? RetrospectEmoticonReasonModel
+    }
+    
     @IBOutlet private weak var collectionView: UICollectionView!
     
 }
@@ -51,20 +55,20 @@ class RetrospectEmotionReasonTableViewCell: RetrospectReportCell {
 extension RetrospectEmotionReasonTableViewCell: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        // TODO: - 서버 데이터 반영 필요
-        return 10
+        emotionReasonPresentable?.reasons.count ?? 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(cell: RetrospectEmotionReasonItemCell.self, forIndexPath: indexPath)
+        let reasons = self.emotionReasonPresentable?.reasons
         
         guard let itemCell = cell else { return UICollectionViewCell() }
-        itemCell.configure(reasonText: "안녕하세요?\n아아아아아아아아")
+        guard let reason = reasons?[safe: indexPath.row] else { return UICollectionViewCell() }
+        
+        itemCell.configure(reasonText: reason)
         return itemCell
     }
     
 }
 
-extension RetrospectEmotionReasonTableViewCell: UICollectionViewDelegate {
-    
-}
+extension RetrospectEmotionReasonTableViewCell: UICollectionViewDelegate {}

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectEmotionTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectEmotionTableViewCell.swift
@@ -11,7 +11,9 @@ import UIKit
 
 class RetrospectEmotionTableViewCell: RetrospectReportCell {
     
-    override class var cellHeight: CGFloat { 16 + 160 }
+    override class var cellHeight: CGFloat {
+        RetrospectLayoutGuide.emotionCellHeight
+    }
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectEmotionTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectEmotionTableViewCell.swift
@@ -23,7 +23,7 @@ class RetrospectEmotionTableViewCell: RetrospectReportCell {
     
     override func configure(presentable: RetrospectReportPresentable) {
         super.configure(presentable: presentable)
-        // TODO: - 서버 데이터 반영
+        self.collectionView.reloadData()
     }
     
     private func layoutCollectionView() {
@@ -38,9 +38,14 @@ class RetrospectEmotionTableViewCell: RetrospectReportCell {
     
     private func setupCollectionView() {
         self.collectionView.registerCell(cell: RetrospectEmotionItemCell.self)
-        self.collectionView.allowsSelection = false
         self.collectionView.dataSource = self
         self.collectionView.delegate = self
+        self.collectionView.allowsSelection = false
+        self.collectionView.showsHorizontalScrollIndicator = false
+    }
+    
+    private var emotionPresentable: RetrospectEmoticonModel? {
+        self.presentable as? RetrospectEmoticonModel
     }
 
     @IBOutlet private weak var collectionView: UICollectionView!
@@ -50,21 +55,19 @@ class RetrospectEmotionTableViewCell: RetrospectReportCell {
 extension RetrospectEmotionTableViewCell: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        // TODO: - 서버 데이터 반영 필요
-        return 4
+        self.emotionPresentable?.emoticons.count ?? 0
     }
-    
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(cell: RetrospectEmotionItemCell.self, forIndexPath: indexPath)
+        let emotions = self.emotionPresentable?.emoticons
         
         guard let itemCell = cell else { return UICollectionViewCell() }
-        itemCell.configure(emotion: .easy)
+        guard let emotion = emotions?[safe: indexPath.row] else { return UICollectionViewCell() }
+        itemCell.configure(emotion: emotion)
         return itemCell
     }
     
 }
 
-extension RetrospectEmotionTableViewCell: UICollectionViewDelegate {
-    
-}
+extension RetrospectEmotionTableViewCell: UICollectionViewDelegate {}

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectFarStarTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectFarStarTableViewCell.swift
@@ -9,7 +9,9 @@ import UIKit
 
 class RetrospectFarStarTableViewCell: RetrospectReportCell {
     
-    override class var cellHeight: CGFloat { 8 + 160 }
+    override class var cellHeight: CGFloat {
+        RetrospectLayoutGuide.farStarCellHeight
+    }
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectFarStarTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectFarStarTableViewCell.swift
@@ -21,8 +21,7 @@ class RetrospectFarStarTableViewCell: RetrospectReportCell {
     
     override func configure(presentable: RetrospectReportPresentable) {
         super.configure(presentable: presentable)
-        
-        // TODO: - 서버 데이터 반영 필요
+        self.collectionView.reloadData()
     }
     
     private func setupCollectionView() {
@@ -36,10 +35,14 @@ class RetrospectFarStarTableViewCell: RetrospectReportCell {
         if let collectionViewLayout = self.collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
             collectionViewLayout.scrollDirection = .horizontal
             collectionViewLayout.itemSize = RetrospectJourneyItemCell.cellSize
-            collectionViewLayout.sectionInset = UIEdgeInsets(top: 0, left: 27, bottom: 0, right: 27)
             collectionViewLayout.minimumLineSpacing = 20
             collectionViewLayout.minimumInteritemSpacing = 0
+            collectionViewLayout.sectionInset = UIEdgeInsets(top: 0, left: 27, bottom: 0, right: 27)
         }
+    }
+    
+    private var farStarPresentable: RetrospectFarStarsModel? {
+        self.presentable as? RetrospectFarStarsModel
     }
     
     @IBOutlet private weak var collectionView: UICollectionView!
@@ -48,21 +51,20 @@ class RetrospectFarStarTableViewCell: RetrospectReportCell {
 
 extension RetrospectFarStarTableViewCell: UICollectionViewDataSource {
     
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        self.farStarPresentable?.farStars.count ?? 0
+    }
+    
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(cell: RetrospectJourneyItemCell.self, forIndexPath: indexPath)
+        let farStars = self.farStarPresentable?.farStars
         
         guard let itemCell = cell else { return UICollectionViewCell() }
-        itemCell.configure(journey: .rest)
+        guard let journey = farStars?[safe: indexPath.row] else { return UICollectionViewCell() }
+        itemCell.configure(journey: journey)
         return itemCell
     }
     
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 5
-    }
-    
 }
 
-
-extension RetrospectFarStarTableViewCell: UICollectionViewDelegate {
-    
-}
+extension RetrospectFarStarTableViewCell: UICollectionViewDelegate {}

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectFarStarTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectFarStarTableViewCell.swift
@@ -28,6 +28,7 @@ class RetrospectFarStarTableViewCell: RetrospectReportCell {
         self.collectionView.registerCell(cell: RetrospectJourneyItemCell.self)
         self.collectionView.dataSource = self
         self.collectionView.delegate = self
+        self.collectionView.allowsSelection = false
         self.collectionView.showsHorizontalScrollIndicator = false
     }
     

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectFoundStarTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectFoundStarTableViewCell.swift
@@ -9,7 +9,9 @@ import UIKit
 
 class RetrospectFoundStarTableViewCell: RetrospectReportCell {
     
-    static override var cellHeight: CGFloat { return 217 }
+    static override var cellHeight: CGFloat {
+        RetrospectLayoutGuide.foundStarCellHeight
+    }
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectFoundStarTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectFoundStarTableViewCell.swift
@@ -29,9 +29,10 @@ class RetrospectFoundStarTableViewCell: RetrospectReportCell {
     
     private func setupCollectionView() {
         self.collectionView.registerCell(cell: RetrospectFoundStarItemCell.self)
-        self.collectionView.showsHorizontalScrollIndicator = false
         self.collectionView.dataSource = self
         self.collectionView.delegate = self
+        self.collectionView.allowsSelection = false
+        self.collectionView.showsHorizontalScrollIndicator = false
     }
     
     private func layoutCollectionView() {

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectReportCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectReportCell.swift
@@ -20,3 +20,11 @@ class RetrospectReportCell: UITableViewCell {
     }
     
 }
+
+struct RetrospectLayoutGuide {
+    static let foundStarCellHeight: CGFloat = 217
+    static let closeStarCellHeight: CGFloat = 160 + 24
+    static let farStarCellHeight: CGFloat = 8 + 160
+    static let emotionCellHeight: CGFloat = 16 + 160
+    static let emotionReasonCellHeight: CGFloat = 30 + 392
+}

--- a/polaris-ios/polaris-ios/Sources/Storyboard/WeekPicker.storyboard
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/WeekPicker.storyboard
@@ -101,18 +101,38 @@
                                     <constraint firstAttribute="bottom" secondItem="i6P-je-HGu" secondAttribute="bottom" id="rzD-Ml-ZQv"/>
                                 </constraints>
                             </view>
+                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5dI-Gf-Mf7">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <subviews>
+                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="cUF-HJ-3b9">
+                                        <rect key="frame" x="197" y="438" width="20" height="20"/>
+                                        <color key="color" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </activityIndicatorView>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="cUF-HJ-3b9" firstAttribute="centerY" secondItem="5dI-Gf-Mf7" secondAttribute="centerY" id="kj0-a6-f0o"/>
+                                    <constraint firstItem="cUF-HJ-3b9" firstAttribute="centerX" secondItem="5dI-Gf-Mf7" secondAttribute="centerX" id="vMt-Yj-OmU"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="abB-EC-nHK" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="5fX-wN-aBe"/>
                             <constraint firstAttribute="bottom" secondItem="abB-EC-nHK" secondAttribute="bottom" id="Gsh-U4-2hh"/>
+                            <constraint firstItem="5dI-Gf-Mf7" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="KEJ-Fx-hfK"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="abB-EC-nHK" secondAttribute="trailing" id="YoU-S4-rdp"/>
+                            <constraint firstAttribute="bottom" secondItem="5dI-Gf-Mf7" secondAttribute="bottom" id="gW0-oz-TqK"/>
+                            <constraint firstItem="5dI-Gf-Mf7" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="hx5-hb-s76"/>
+                            <constraint firstItem="5dI-Gf-Mf7" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="so7-zE-FxL"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="closeButton" destination="6Jc-kZ-ec0" id="Lf0-l1-3Fr"/>
                         <outlet property="confirmButton" destination="fyO-z8-mcK" id="mx1-NF-aNg"/>
+                        <outlet property="indicatorContainerView" destination="5dI-Gf-Mf7" id="iHF-0m-4pF"/>
+                        <outlet property="indicatorView" destination="cUF-HJ-3b9" id="wjf-xG-WD0"/>
                         <outlet property="lineView" destination="eow-sM-6LY" id="hbs-sd-TNK"/>
                         <outlet property="titleLabel" destination="BFS-r8-RB8" id="CSV-16-vpl"/>
                         <outlet property="weekPicker" destination="mEV-qo-j5f" id="BJm-hr-rfm"/>

--- a/polaris-ios/polaris-ios/Sources/ViewController/AddTodoVC.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/AddTodoVC.swift
@@ -50,6 +50,10 @@ class AddTodoVC: HalfModalVC {
         self.viewModel.setEditTodoModel(todo)
     }
     
+    func setAddJourneyDate(_ date: PolarisDate) {
+        self.viewModel.setAddJourneyDate(date)
+    }
+    
     private func setupTitleLabel() {
         if self.viewModel.currentAddOption == .perDayAddTodo {
             guard let date = self.viewModel.currentDate else { return }
@@ -231,6 +235,7 @@ extension AddTodoVC: UITableViewDelegate {
 }
 
 extension AddTodoVC {
+    
     struct AddOptions: OptionSet {
         let rawValue: Int
         
@@ -258,4 +263,5 @@ extension AddTodoVC {
             return cellTypes
         }
     }
+    
 }

--- a/polaris-ios/polaris-ios/Sources/ViewController/Common/PolarisWebViewController.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/Common/PolarisWebViewController.swift
@@ -77,7 +77,7 @@ extension PolarisWebViewController: PolarisWebViewNavigationDelegate {
     }
     
     func polarisWebView(_ polarisWebView: PolarisWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        #warning("나중에 에러 로직 UX 관련해서 처리")
+
     }
     
 }

--- a/polaris-ios/polaris-ios/Sources/ViewController/Intro/LoginVC.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/Intro/LoginVC.swift
@@ -53,6 +53,7 @@ final class LoginVC: UIViewController {
     }
     
     private func setupLoadingView() {
+        self.loadingIndicator.color = .white
         self.view.addSubview(self.loadingView)
         self.loadingView.snp.makeConstraints { make in
             make.edges.equalToSuperview()

--- a/polaris-ios/polaris-ios/Sources/ViewController/Retrospect/RetrospectReportVC.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/Retrospect/RetrospectReportVC.swift
@@ -67,8 +67,7 @@ class RetrospectReportVC: UIViewController {
                 let foundStarModel = tuple.1
                                 
                 owner.tableView.reloadData()
-                
-                // TODO: - Empty View 처리
+                owner.updateEmptyViewUI(asFoundStar: foundStarModel, asRetrospect: retrospectModel)
             })
             .disposed(by: self.disposeBag)
         
@@ -101,6 +100,22 @@ class RetrospectReportVC: UIViewController {
         self.indicatorView.stopAnimating()
     }
     
+    private func updateEmptyViewUI(asFoundStar foundStar: RetrospectValueListModel, asRetrospect retrospect: RetrospectModel?) {
+        if foundStar.isAchieveJourneyAtLeastOne == false {
+            self.todoEmptyView.showCrossDissolve()
+            self.retrospectEmptyView.hideCrossDissolve()
+        } else if foundStar.isAchieveJourneyAtLeastOne == true && retrospect == nil {
+            self.todoEmptyView.hideCrossDissolve()
+            self.retrospectEmptyView.showCrossDissolve()
+        } else if foundStar.isAchieveJourneyAtLeastOne == true && retrospect != nil {
+            self.todoEmptyView.hideCrossDissolve()
+            self.retrospectEmptyView.hideCrossDissolve()
+        } else {
+            self.todoEmptyView.showCrossDissolve()
+            self.retrospectEmptyView.hideCrossDissolve()
+        }
+    }
+    
     private let disposeBag = DisposeBag()
     private let viewModel = RetrospectReportViewModel()
     
@@ -108,6 +123,8 @@ class RetrospectReportVC: UIViewController {
     @IBOutlet private weak var backButton: UIButton!
     @IBOutlet private weak var calendarButton: UIButton!
     @IBOutlet private weak var tableView: UITableView!
+    @IBOutlet private weak var todoEmptyView: UIView!
+    @IBOutlet private weak var retrospectEmptyView: UIView!
     
     @IBOutlet private weak var indicatorContainerView: UIView!
     @IBOutlet private weak var indicatorView: UIActivityIndicatorView!

--- a/polaris-ios/polaris-ios/Sources/ViewController/Retrospect/RetrospectReportVC.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/Retrospect/RetrospectReportVC.swift
@@ -167,8 +167,7 @@ extension RetrospectReportVC: UITableViewDelegate {
 
 extension RetrospectReportVC: WeekPickerDelegate {
     
-    func apply(year: Int, month: Int, weekNo: Int, weekText: String) {
-        let date = PolarisDate(year: year, month: month, weekNo: weekNo)
+    func weekPickerViewController(_ viewController: WeekPickerVC, didSelectedDate date: PolarisDate) {
         self.viewModel.occurViewAction(action: .weekPickerSelected(date: date))
     }
     

--- a/polaris-ios/polaris-ios/Sources/ViewController/Retrospect/RetrospectReportVC.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/Retrospect/RetrospectReportVC.swift
@@ -55,11 +55,10 @@ class RetrospectReportVC: UIViewController {
             .withUnretained(self)
             .observeOnMain(onNext: { owner, currentDate in
                 let currentDate = currentDate
-                let weekNoDic = [1: "첫째주", 2: "둘째주", 3: "셋째주", 4: "넷째주", 5: "다섯째주"]
                 
                 let yearText = "\(currentDate.year)년 "
                 let monthText = "\(currentDate.month)월 "
-                guard let weekNoText = weekNoDic[currentDate.weekNo] else { return }
+                guard let weekNoText = Date.convertWeekNoToString(weekNo: currentDate.weekNo) else { return }
                 
                 self.dateLabel.text = yearText + monthText + weekNoText
             })

--- a/polaris-ios/polaris-ios/Sources/ViewController/Retrospect/RetrospectReportVC.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/Retrospect/RetrospectReportVC.swift
@@ -10,6 +10,10 @@ import RxSwift
 import UIKit
 
 class RetrospectReportVC: UIViewController {
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        .lightContent
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/polaris-ios/polaris-ios/Sources/ViewController/WeekPickerVC.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/WeekPickerVC.swift
@@ -48,16 +48,9 @@ class WeekPickerVC: HalfModalVC {
     
     @IBAction func confirmButtonAction(_ sender: Any) {
         guard let selectedDate = self.viewModel.selectedDate                           else { return }
-        guard let weekNoText = self.convertWeekNoToString(weekNo: selectedDate.weekNo) else { return }
-        
-        let dateAsText = "\(selectedDate.year)년 " + "\(selectedDate.month)월 " + weekNoText
-        self.weekDelegate?.apply(
-            year: selectedDate.year,
-            month: selectedDate.month,
-            weekNo: selectedDate.weekNo,
-            weekText: dateAsText
-        )
-      
+        guard let weekNoText = Date.convertWeekNoToString(weekNo: selectedDate.weekNo) else { return }
+    
+        self.weekDelegate?.weekPickerViewController(self, didSelectedDate: selectedDate)
         self.dismissWithAnimation()
     }
     
@@ -188,7 +181,7 @@ extension WeekPickerVC: UIPickerViewDelegate {
 }
 
 protocol WeekPickerDelegate: AnyObject {
-    func apply(year: Int, month: Int, weekNo: Int, weekText: String)
+    func weekPickerViewController(_ viewController: WeekPickerVC, didSelectedDate date: PolarisDate)
 }
 
 

--- a/polaris-ios/polaris-ios/Sources/ViewController/WeekPickerVC.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/WeekPickerVC.swift
@@ -28,7 +28,7 @@ class WeekPickerVC: HalfModalVC {
         self.setUIs()
         self.observeViewModel()
         
-        self.viewModel.occurViewAction(action: .requestWeekInformation)
+        self.viewModel.occurViewAction(action: .viewDidLoad)
     }
     
     private func setUIs(){
@@ -48,16 +48,15 @@ class WeekPickerVC: HalfModalVC {
     }
     
     @IBAction func confirmButtonAction(_ sender: Any) {
-        let currentSelectedDate = self.viewModel.selectedDate
+        guard let selectedDate = self.viewModel.selectedDate                           else { return }
+        guard let weekNoText = self.convertWeekNoToString(weekNo: selectedDate.weekNo) else { return }
         
-        if let weekNoText = self.convertWeekNoToString(weekNo: currentSelectedDate.weekNo) {
-            let dateAsText = "\(currentSelectedDate.year)년 " + "\(currentSelectedDate.month)월 " + weekNoText
-            self.weekDelegate?.apply(year: currentSelectedDate.year,
-                                     month: currentSelectedDate.month,
-                                     weekNo: currentSelectedDate.weekNo,
-                                     weekText: dateAsText
-            )
-        }
+        let dateAsText = "\(selectedDate.year)년 " + "\(selectedDate.month)월 " + weekNoText
+        self.weekDelegate?.apply(year: selectedDate.year,
+                                 month: selectedDate.month,
+                                 weekNo: selectedDate.weekNo,
+                                 weekText: dateAsText
+        )
       
         self.dismissWithAnimation()
     }
@@ -87,7 +86,7 @@ class WeekPickerVC: HalfModalVC {
             .take(1)
             .withUnretained(self)
             .observeOnMain(onNext: { owner, _ in
-                let selectedDate = owner.viewModel.selectedDate
+                guard let selectedDate = owner.viewModel.selectedDate else { return }
                 
                 let yearRow = owner.viewModel.years.firstIndex(of: selectedDate.year) ?? 0
                 let monthRow = selectedDate.month - 1
@@ -128,7 +127,7 @@ extension WeekPickerVC: UIPickerViewDataSource {
             return Calendar.current.monthSymbols.count
         case .weekNo:
             let defaultWeekNo: Int = 4
-            let currentSelectedDate = self.viewModel.selectedDate
+            guard let currentSelectedDate = self.viewModel.selectedDate else { return defaultWeekNo }
             return self.viewModel.weekNo(ofYear: currentSelectedDate.year, ofMonth: currentSelectedDate.month) ?? defaultWeekNo
         }
     }
@@ -148,9 +147,9 @@ extension WeekPickerVC: UIPickerViewDelegate {
         
         switch pickerComponent {
         case .year:
-            return "\(self.viewModel.years[safe: row] ?? Date.currentYear)"+"년"
+            return "\(self.viewModel.years[safe: row] ?? Date.currentYear)" + "년"
         case .month:
-            return "\(row + 1)"+"월"
+            return "\(row + 1)" + "월"
         case .weekNo:
             return self.convertWeekNoToString(weekNo: row + 1)
         }
@@ -159,7 +158,7 @@ extension WeekPickerVC: UIPickerViewDelegate {
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         guard let pickerComponent = PickerComponent(rawValue: component) else { return }
         
-        let currentSelectedDate = self.viewModel.selectedDate
+        guard let currentSelectedDate = self.viewModel.selectedDate else { return }
         
         switch pickerComponent {
         case .year:

--- a/polaris-ios/polaris-ios/Sources/ViewController/WeekPickerVC.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/WeekPickerVC.swift
@@ -48,8 +48,7 @@ class WeekPickerVC: HalfModalVC {
     
     @IBAction func confirmButtonAction(_ sender: Any) {
         guard let selectedDate = self.viewModel.selectedDate                           else { return }
-        guard let weekNoText = Date.convertWeekNoToString(weekNo: selectedDate.weekNo) else { return }
-    
+        
         self.weekDelegate?.weekPickerViewController(self, didSelectedDate: selectedDate)
         self.dismissWithAnimation()
     }

--- a/polaris-ios/polaris-ios/Sources/ViewController/WeekPickerVC.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/WeekPickerVC.swift
@@ -5,6 +5,7 @@
 //  Created by Yunjae Kim on 2021/08/16.
 //
 
+import RxSwift
 import UIKit
 
 class WeekPickerVC: HalfModalVC {
@@ -15,14 +16,7 @@ class WeekPickerVC: HalfModalVC {
     @IBOutlet weak var lineView: UIView!
     @IBOutlet weak var confirmButton: UIButton!
     @IBOutlet weak var weekPicker: UIPickerView!
-    
-    private var year = Date.currentYear
-    private var month = Date.currentMonth
-    private var weekNo = Date.currentWeekNoOfMonth
-    
-    private var yearList: [Int] = [Date.currentYear-2,Date.currentYear-1,Date.currentYear,Date.currentYear+1,Date.currentYear+2]
-    private var monthList = [1,2,3,4,5,6,7,8,9,10,11,12]
-    
+        
     private let weekDict = [1:"첫째주",2:"둘째주",3:"셋째주",4:"넷째주",5:"다섯째주"]
     weak var weekDelegate: WeekPickerDelegate?
     
@@ -32,6 +26,9 @@ class WeekPickerVC: HalfModalVC {
         self.weekPicker.delegate = self
         self.weekPicker.dataSource = self
         self.setUIs()
+        self.observeViewModel()
+        
+        self.viewModel.occurViewAction(action: .requestWeekInformation)
     }
     
     private func setUIs(){
@@ -44,15 +41,6 @@ class WeekPickerVC: HalfModalVC {
         self.confirmButton.makeRounded(cornerRadius: 18)
         self.weekPicker.setValue(UIColor.maintext, forKeyPath: "textColor")
         self.weekPicker.subviews.first?.subviews.last?.backgroundColor = UIColor.red
-        self.setWeekPicker()
-    }
-    
-    private func setWeekPicker() {
-        self.weekPicker.selectRow(self.month-1, inComponent: 1, animated: false)
-        self.weekPicker.selectRow(self.weekNo-1, inComponent: 2, animated: false)
-        
-        guard let yearIndex = self.yearList.firstIndex(of: self.year) else { return }
-        self.weekPicker.selectRow(yearIndex, inComponent: 0, animated: false)
     }
     
     @IBAction func closeButtonAction(_ sender: Any) {
@@ -60,37 +48,88 @@ class WeekPickerVC: HalfModalVC {
     }
     
     @IBAction func confirmButtonAction(_ sender: Any) {
-        if let weekNoText = weekDict[self.weekNo] {
-            self.weekDelegate?.apply(year: self.year,
-                                     month: self.month,
-                                     weekNo: self.weekNo,
-                                     weekText: String(self.year)+"년 "+String(self.month)+"월 "+weekNoText
+        let currentSelectedDate = self.viewModel.selectedDate
+        
+        if let weekNoText = self.convertWeekNoToString(weekNo: currentSelectedDate.weekNo) {
+            let dateAsText = "\(currentSelectedDate.year)년 " + "\(currentSelectedDate.month)월 " + weekNoText
+            self.weekDelegate?.apply(year: currentSelectedDate.year,
+                                     month: currentSelectedDate.month,
+                                     weekNo: currentSelectedDate.weekNo,
+                                     weekText: dateAsText
             )
         }
       
         self.dismissWithAnimation()
     }
     
-    public func setWeekInfo(year: Int, month: Int, weekNo: Int) {
-        self.year = year
-        self.month = month
-        self.weekNo = weekNo
+    func setWeekInfo(year: Int, month: Int, weekNo: Int) {
+        let date = PolarisDate(year: year, month: month, weekNo: weekNo)
+        self.viewModel.occurViewAction(action: .pickerSelected(date: date))
     }
+    
+    private func observeViewModel() {
+        self.viewModel.loadingObservable
+            .withUnretained(self)
+            .observeOnMain(onNext: { owner, loading in
+                owner.indicatorContainerView.isHidden = loading == false
+                loading ? owner.indicatorView.startAnimating() : owner.indicatorView.stopAnimating()
+            })
+            .disposed(by: self.disposeBag)
+            
+        self.viewModel.reloadObservable
+            .withUnretained(self)
+            .observeOnMain(onNext: { owner, _ in
+                owner.weekPicker.reloadAllComponents()
+            })
+            .disposed(by: self.disposeBag)
+        
+        self.viewModel.reloadObservable
+            .take(1)
+            .withUnretained(self)
+            .observeOnMain(onNext: { owner, _ in
+                let selectedDate = owner.viewModel.selectedDate
+                
+                let yearRow = owner.viewModel.years.firstIndex(of: selectedDate.year) ?? 0
+                let monthRow = selectedDate.month - 1
+                let weekNoRow = selectedDate.weekNo - 1
+                
+                owner.weekPicker.selectRow(yearRow, inComponent: PickerComponent.year.rawValue, animated: false)
+                owner.weekPicker.selectRow(monthRow, inComponent: PickerComponent.month.rawValue, animated: false)
+                owner.weekPicker.selectRow(weekNoRow, inComponent: PickerComponent.weekNo.rawValue, animated: false)
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
+    private func convertWeekNoToString(weekNo: Int) -> String? {
+        let weekDict = [1: "첫째주", 2: "둘째주", 3: "셋째주", 4: "넷째주", 5: "다섯째주"]
+        return weekDict[weekNo]
+    }
+    
+    private let viewModel = WeekPickerViewModel()
+    private let disposeBag = DisposeBag()
+    
+    @IBOutlet private weak var indicatorView: UIActivityIndicatorView!
+    @IBOutlet private weak var indicatorContainerView: UIView!
+    
 }
 
 extension WeekPickerVC: UIPickerViewDataSource {
     func numberOfComponents(in pickerView: UIPickerView) -> Int {
-        3
+        PickerComponent.allCases.count
     }
     
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        switch component {
-        case 0:
-            return self.yearList.count
-        case 1:
-            return self.monthList.count
-        default:
-            return Date.numberOfMondaysInMonth(self.month, forYear: self.year) ?? 4
+        guard let pickerComponent = PickerComponent(rawValue: component) else { return 0 }
+        
+        switch pickerComponent {
+        case .year:
+            return self.viewModel.years.count
+        case .month:
+            return Calendar.current.monthSymbols.count
+        case .weekNo:
+            let defaultWeekNo: Int = 4
+            let currentSelectedDate = self.viewModel.selectedDate
+            return self.viewModel.weekNo(ofYear: currentSelectedDate.year, ofMonth: currentSelectedDate.month) ?? defaultWeekNo
         }
     }
     
@@ -104,27 +143,51 @@ extension WeekPickerVC: UIPickerViewDelegate {
     
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
         pickerView.subviews[1].backgroundColor = .mainSky15
-        switch component {
-        case 0:
-            return String(self.yearList[row])+"년"
-        case 1:
-            return String(self.monthList[row])+"월"
-        default:
-            return weekDict[row+1]
+        
+        guard let pickerComponent = PickerComponent(rawValue: component) else { return nil }
+        
+        switch pickerComponent {
+        case .year:
+            return "\(self.viewModel.years[safe: row] ?? Date.currentYear)"+"년"
+        case .month:
+            return "\(row + 1)"+"월"
+        case .weekNo:
+            return self.convertWeekNoToString(weekNo: row + 1)
         }
     }
     
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        switch component {
-        case 0:
-            self.year = yearList[row]
-            self.weekPicker.reloadComponent(0)
-        case 1:
-            self.month = monthList[row]
-            self.weekPicker.reloadComponent(1)
-        default:
-            self.weekNo = row+1
-            self.weekPicker.reloadComponent(2)
+        guard let pickerComponent = PickerComponent(rawValue: component) else { return }
+        
+        let currentSelectedDate = self.viewModel.selectedDate
+        
+        switch pickerComponent {
+        case .year:
+            let selectedDate = PolarisDate(
+                year: self.viewModel.years[safe: row] ?? Date.currentYear,
+                month: currentSelectedDate.month,
+                weekNo: currentSelectedDate.weekNo
+            )
+            self.viewModel.occurViewAction(action: .pickerSelected(date: selectedDate))
+            self.weekPicker.reloadAllComponents()
+            
+        case .month:
+            let selectedDate = PolarisDate(
+                year: currentSelectedDate.year,
+                month: row + 1,
+                weekNo: currentSelectedDate.weekNo
+            )
+            self.viewModel.occurViewAction(action: .pickerSelected(date: selectedDate))
+            self.weekPicker.reloadAllComponents()
+            
+        case .weekNo:
+            let selectedDate = PolarisDate(
+                year: currentSelectedDate.year,
+                month: currentSelectedDate.month,
+                weekNo: row + 1
+            )
+            self.viewModel.occurViewAction(action: .pickerSelected(date: selectedDate))
+            self.weekPicker.reloadAllComponents()
         }
     }
     
@@ -132,4 +195,13 @@ extension WeekPickerVC: UIPickerViewDelegate {
 
 protocol WeekPickerDelegate: AnyObject {
     func apply(year: Int, month: Int, weekNo: Int, weekText: String)
+}
+
+
+extension WeekPickerVC {
+    
+    enum PickerComponent: Int, CaseIterable {
+        case year, month, weekNo
+    }
+    
 }

--- a/polaris-ios/polaris-ios/Sources/ViewController/WeekPickerVC.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/WeekPickerVC.swift
@@ -52,10 +52,11 @@ class WeekPickerVC: HalfModalVC {
         guard let weekNoText = self.convertWeekNoToString(weekNo: selectedDate.weekNo) else { return }
         
         let dateAsText = "\(selectedDate.year)년 " + "\(selectedDate.month)월 " + weekNoText
-        self.weekDelegate?.apply(year: selectedDate.year,
-                                 month: selectedDate.month,
-                                 weekNo: selectedDate.weekNo,
-                                 weekText: dateAsText
+        self.weekDelegate?.apply(
+            year: selectedDate.year,
+            month: selectedDate.month,
+            weekNo: selectedDate.weekNo,
+            weekText: dateAsText
         )
       
         self.dismissWithAnimation()

--- a/polaris-ios/polaris-ios/Sources/ViewController/WeekPickerVC.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/WeekPickerVC.swift
@@ -17,7 +17,6 @@ class WeekPickerVC: HalfModalVC {
     @IBOutlet weak var confirmButton: UIButton!
     @IBOutlet weak var weekPicker: UIPickerView!
         
-    private let weekDict = [1:"첫째주",2:"둘째주",3:"셋째주",4:"넷째주",5:"다섯째주"]
     weak var weekDelegate: WeekPickerDelegate?
     
     override func viewDidLoad() {
@@ -100,11 +99,6 @@ class WeekPickerVC: HalfModalVC {
             .disposed(by: self.disposeBag)
     }
     
-    private func convertWeekNoToString(weekNo: Int) -> String? {
-        let weekDict = [1: "첫째주", 2: "둘째주", 3: "셋째주", 4: "넷째주", 5: "다섯째주"]
-        return weekDict[weekNo]
-    }
-    
     private let viewModel = WeekPickerViewModel()
     private let disposeBag = DisposeBag()
     
@@ -152,7 +146,7 @@ extension WeekPickerVC: UIPickerViewDelegate {
         case .month:
             return "\(row + 1)" + "월"
         case .weekNo:
-            return self.convertWeekNoToString(weekNo: row + 1)
+            return Date.convertWeekNoToString(weekNo: row + 1)
         }
     }
     

--- a/polaris-ios/polaris-ios/Sources/ViewModel/Intro/SignupViewModel.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewModel/Intro/SignupViewModel.swift
@@ -62,7 +62,6 @@ final class SignupViewModel {
                 PolarisUserManager.shared.updateUser(signupModel)
                 completion()
             }, onFailure: { error in
-                #warning("네트워크 에러일 때, 처리 필요")
                 print(error.localizedDescription)
             })
             .disposed(by: self.disposeBag)
@@ -102,7 +101,6 @@ final class SignupViewModel {
                 if checkEmailModel.isDuplicated == true { self.idDuplicatedValidRelay.accept(false) }
                 else { self.idDuplicatedValidRelay.accept(true) }
             }, onFailure: { [weak self] error in
-                #warning("여기도 에러인 경우 따로 처리 필요할 듯")
                 self?.idDuplicatedValidRelay.accept(false)
             })
             .disposed(by: self.disposeBag)

--- a/polaris-ios/polaris-ios/Sources/ViewModel/LookBackViewModel.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewModel/LookBackViewModel.swift
@@ -394,7 +394,7 @@ final class LookBackViewModel {
         
         let resultModel = RetrospectModel(year: Date.currentYear, month: Date.currentMonth, weekNo: Date.currentWeekNoOfMonth, value: resultValue, record1: recordInfo[0], record2: recordInfo[1], record3: recordInfo[2])
         
-        let registAPI = RetrospectAPI.createLookBack(model: resultModel)
+        let registAPI = RetrospectAPI.create(model: resultModel)
         
         NetworkManager.request(apiType: registAPI)
             .subscribe(onSuccess: { [weak self] (responseModel: RetrospectResponseModel) in

--- a/polaris-ios/polaris-ios/Sources/ViewModel/MainSceneViewModel.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewModel/MainSceneViewModel.swift
@@ -105,7 +105,7 @@ class MainSceneViewModel {
         
         let weekAPI = WeekAPI.getWeekNo(date: Date.normalizedCurrent)
         NetworkManager.request(apiType: weekAPI)
-            .subscribe(onSuccess: { [weak self] (weekModel: WeekResponseModel) in
+            .subscribe(onSuccess: { (weekModel: WeekResponseModel) in
                 var year = Date.currentYear
                 var month = Date.currentMonth
                 if Date.todayDay < 7 * (weekModel.weekNo - 1) {
@@ -117,7 +117,7 @@ class MainSceneViewModel {
                         month -= 1
                     }
                 }
-                input.dateInfo.accept(DateInfo(year: year, month: month, weekNo: weekModel.weekNo))
+                input.dateInfo.accept(PolarisDate(year: year, month: month, weekNo: weekModel.weekNo))
             })
             .disposed(by: self.disposeBag)
         

--- a/polaris-ios/polaris-ios/Sources/ViewModel/MainSceneViewModel.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewModel/MainSceneViewModel.swift
@@ -9,12 +9,6 @@ import Foundation
 import RxSwift
 import RxCocoa
 
-struct DateInfo {
-    let year: Int
-    let month: Int
-    let weekNo: Int
-}
-
 class MainSceneViewModel {
     
     var heightRatio = CGFloat(DeviceInfo.screenHeight/812.0)
@@ -24,7 +18,7 @@ class MainSceneViewModel {
     private let deviceRatio = DeviceInfo.screenHeight/812.0
     struct Input{
         let forceToShowStar: BehaviorRelay<Bool>
-        let dateInfo: BehaviorRelay<DateInfo>
+        let dateInfo: BehaviorRelay<PolarisDate>
     }
     
     struct Output{
@@ -142,7 +136,7 @@ class MainSceneViewModel {
         return resultList
     }
     
-    func convertTodoCVCViewModel(weekJourneyModels: [WeekJourneyModel],dateInfo: DateInfo) -> [MainTodoCVCViewModel]{
+    func convertTodoCVCViewModel(weekJourneyModels: [WeekJourneyModel],dateInfo: PolarisDate) -> [MainTodoCVCViewModel]{
         var resultList: [MainTodoCVCViewModel] = []
         var thisWeekJouneyModels: [WeekJourneyModel] = []
         // 이번주에 해당하는 Model 추출
@@ -191,7 +185,7 @@ class MainSceneViewModel {
         self.forceToShowStarRelay.accept(isSkipped)
     }
     
-    func updateDateInfo(_ dateInfo: DateInfo) {
+    func updateDateInfo(_ dateInfo: PolarisDate) {
         self.dateInfoRelay.accept(dateInfo)
     }
     
@@ -235,7 +229,7 @@ class MainSceneViewModel {
     }
     
     private(set) var forceToShowStarRelay = BehaviorRelay(value: false)
-    private(set) var dateInfoRelay        = BehaviorRelay<DateInfo>(value: DateInfo(year: Date.currentYear,
+    private(set) var dateInfoRelay        = BehaviorRelay<PolarisDate>(value: PolarisDate(year: Date.currentYear,
                                                                                     month: Date.currentMonth,
                                                                                     weekNo: Date.currentWeekNoOfMonth))
     

--- a/polaris-ios/polaris-ios/Sources/ViewModel/Setting/NickChangeViewModel.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewModel/Setting/NickChangeViewModel.swift
@@ -1,0 +1,31 @@
+//
+//  NickChangeViewModel.swift
+//  polaris-ios
+//
+//  Created by Dongmin on 2022/02/09.
+//
+
+import RxSwift
+import Foundation
+
+final class NickChangeViewModel {
+    
+    let loadingSubject = PublishSubject<Bool>()
+    let completeSubejct = PublishSubject<Void>()
+    
+    func requestChangeNickname(nickname: String) {
+        self.loadingSubject.onNext(true)
+        let userAPI = UserAPI.updateUser(nickname: nickname)
+        
+        NetworkManager.request(apiType: userAPI).subscribe(onSuccess: { [weak self] (polarisUser: PolarisUser) in
+            PolarisUserManager.shared.updateUser(polarisUser)
+            self?.loadingSubject.onNext(false)
+            self?.completeSubejct.onNext(())
+        }, onFailure: { error in
+            self.loadingSubject.onNext(false)
+        }).disposed(by: self.disposeBag)
+    }
+    
+    private let disposeBag = DisposeBag()
+    
+}

--- a/polaris-ios/polaris-ios/Sources/ViewModel/WeekPickerViewModel.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewModel/WeekPickerViewModel.swift
@@ -6,31 +6,77 @@
 //
 
 import RxSwift
+import RxRelay
 import Foundation
 
 final class WeekPickerViewModel {
+            
+    var loadingObservable: Observable<Bool> {
+        self.loadingSubject.asObservable()
+    }
     
-    let loadingSubject = PublishSubject<Bool>()
+    var reloadObservable: Observable<Void> {
+        self.loadingSubject
+            .filter({ $0 == false })
+            .map { _ in }
+            .asObservable()
+    }
+    
+    var years: [Int] {
+        self.lastWeekOfMonthModel.map { $0.year }
+    }
     
     init(weekReposotiroy: WeekRepository = WeekRepositoryImpl()) {
         self.weekRepository = weekReposotiroy
     }
     
-    func requestLastMonthOfWeek() {
-        
+    func weekNo(ofYear year: Int, ofMonth month: Int) -> Int? {
+        guard let monthModel = self.lastWeekOfMonthModel.first(where: { $0.year == year }) else { return nil }
+        return monthModel.weekNo(ofMonth: month)
     }
     
-    private(set) var yearList: [Int] = [
-        Date.currentYear - 2,
-        Date.currentYear - 1,
-        Date.currentYear,
-        Date.currentYear + 1,
-        Date.currentYear + 2
-    ]
+    func occurViewAction(action: ViewAction) {
+        switch action {
+        case .requestWeekInformation:
+            self.requestWeekInformation()
+        case .pickerSelected(let date):
+            self.updateSelectedDate(date: date)
+        }
+    }
     
-    private(set) var monthList: [Int] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    private func requestWeekInformation() {
+        self.loadingSubject.onNext(true)
+        
+        self.weekRepository.fetchLastWeekOfMonth()
+            .catchAndReturn([])
+            .withUnretained(self)
+            .subscribe(onNext: { owner, model in
+                owner.lastWeekOfMonthModel = model
+                owner.loadingSubject.onNext(false)
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
+    private func updateSelectedDate(date: PolarisDate) {
+        self.selectedDate = date
+    }
+    
+    private(set) var selectedDate = PolarisDate(year: 2022, month: 12, weekNo: 4)
+    private var lastWeekOfMonthModel = [LastWeekOfMonthDataModel]()
+    
+    private let loadingSubject = PublishSubject<Bool>()
+    private let requestedSubject = PublishSubject<Void>()
     
     private let weekRepository: WeekRepository
     private let disposeBag = DisposeBag()
+    
+}
+
+extension WeekPickerViewModel {
+    
+    enum ViewAction {
+        case requestWeekInformation
+        case pickerSelected(date: PolarisDate)
+    }
     
 }

--- a/polaris-ios/polaris-ios/Sources/ViewModel/WeekPickerViewModel.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewModel/WeekPickerViewModel.swift
@@ -1,0 +1,36 @@
+//
+//  WeekPickerViewModel.swift
+//  polaris-ios
+//
+//  Created by Dongmin on 2022/02/09.
+//
+
+import RxSwift
+import Foundation
+
+final class WeekPickerViewModel {
+    
+    let loadingSubject = PublishSubject<Bool>()
+    
+    init(weekReposotiroy: WeekRepository = WeekRepositoryImpl()) {
+        self.weekRepository = weekReposotiroy
+    }
+    
+    func requestLastMonthOfWeek() {
+        
+    }
+    
+    private(set) var yearList: [Int] = [
+        Date.currentYear - 2,
+        Date.currentYear - 1,
+        Date.currentYear,
+        Date.currentYear + 1,
+        Date.currentYear + 2
+    ]
+    
+    private(set) var monthList: [Int] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    
+    private let weekRepository: WeekRepository
+    private let disposeBag = DisposeBag()
+    
+}

--- a/polaris-ios/polaris-ios/Sources/ViewModel/WeekPickerViewModel.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewModel/WeekPickerViewModel.swift
@@ -31,8 +31,9 @@ final class WeekPickerViewModel {
     }
     
     func weekNo(ofYear year: Int, ofMonth month: Int) -> Int? {
-        guard let monthModel = self.lastWeekOfMonthModel.first(where: { $0.year == year }) else { return nil }
-        return monthModel.weekNo(ofMonth: month)
+        self.lastWeekOfMonthModel
+            .first(where: { $0.year == year })?
+            .weekNo(ofMonth: month)
     }
     
     func occurViewAction(action: ViewAction) {

--- a/polaris-ios/polaris-ios/Sources/Xib/TableViewCell/LookBackFifthTableViewCell.xib
+++ b/polaris-ios/polaris-ios/Sources/Xib/TableViewCell/LookBackFifthTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -27,8 +27,8 @@
                                     <constraint firstAttribute="height" constant="48" id="Bqt-KZ-tmj"/>
                                     <constraint firstAttribute="width" constant="48" id="Z5h-hE-su8"/>
                                 </constraints>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="color" keyPath="imageTintColor">
                                         <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/polaris-ios/polaris-ios/Sources/Xib/View/ConfirmPopupView.xib
+++ b/polaris-ios/polaris-ios/Sources/Xib/View/ConfirmPopupView.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -19,19 +20,19 @@
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.45000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kM2-Zr-wMJ">
-                    <rect key="frame" x="35" y="369" width="344" height="168"/>
+                    <rect key="frame" x="54.5" y="369" width="305" height="168"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5ez-EV-gCf">
-                            <rect key="frame" x="25" y="34" width="294" height="21"/>
+                            <rect key="frame" x="25" y="34" width="255" height="21"/>
                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                             <color key="textColor" name="mainText"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7tE-Ac-8Ug">
-                            <rect key="frame" x="25" y="95" width="294" height="44"/>
+                            <rect key="frame" x="25" y="95" width="255" height="44"/>
                             <color key="backgroundColor" name="mainPurple"/>
                             <constraints>
-                                <constraint firstAttribute="width" secondItem="7tE-Ac-8Ug" secondAttribute="height" multiplier="147:22" id="9oS-tj-1Mi"/>
+                                <constraint firstAttribute="height" constant="44" id="4PY-Au-gku"/>
                             </constraints>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                             <state key="normal" title="확인">
@@ -44,7 +45,7 @@
                             </userDefinedRuntimeAttributes>
                         </button>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="subTitle" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xmR-ez-TOU">
-                            <rect key="frame" x="25" y="64" width="294" height="18"/>
+                            <rect key="frame" x="25" y="64" width="255" height="18"/>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                             <color key="textColor" name="mainText"/>
                             <nil key="highlightedColor"/>
@@ -55,6 +56,7 @@
                         <constraint firstItem="5ez-EV-gCf" firstAttribute="leading" secondItem="kM2-Zr-wMJ" secondAttribute="leading" constant="25" id="DqF-yc-SSW"/>
                         <constraint firstAttribute="bottom" secondItem="7tE-Ac-8Ug" secondAttribute="bottom" constant="29" id="FaI-VS-zwd"/>
                         <constraint firstItem="7tE-Ac-8Ug" firstAttribute="leading" secondItem="kM2-Zr-wMJ" secondAttribute="leading" constant="25" id="HW3-Uw-vnT"/>
+                        <constraint firstAttribute="width" constant="305" id="Jvj-Jr-9T5"/>
                         <constraint firstAttribute="trailing" secondItem="xmR-ez-TOU" secondAttribute="trailing" constant="25" id="Mar-iL-2zi"/>
                         <constraint firstItem="7tE-Ac-8Ug" firstAttribute="top" secondItem="xmR-ez-TOU" secondAttribute="bottom" constant="13" id="Xb2-38-iSg"/>
                         <constraint firstItem="xmR-ez-TOU" firstAttribute="centerX" secondItem="kM2-Zr-wMJ" secondAttribute="centerX" id="bDv-As-8Iw"/>
@@ -75,12 +77,11 @@
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="3J4-gQ-uzX" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="7yc-8f-HgX"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="kM2-Zr-wMJ" secondAttribute="trailing" constant="35" id="AMM-hc-Sxk"/>
                 <constraint firstAttribute="bottom" secondItem="3J4-gQ-uzX" secondAttribute="bottom" id="Sqp-8M-7Q3"/>
                 <constraint firstItem="3J4-gQ-uzX" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="VQH-fp-DX7"/>
+                <constraint firstItem="kM2-Zr-wMJ" firstAttribute="centerX" secondItem="3J4-gQ-uzX" secondAttribute="centerX" id="bVH-tz-8kQ"/>
                 <constraint firstItem="3J4-gQ-uzX" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="dPd-Wu-Ten"/>
                 <constraint firstItem="kM2-Zr-wMJ" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="hil-dG-goD"/>
-                <constraint firstItem="kM2-Zr-wMJ" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="35" id="uVY-ur-fbo"/>
             </constraints>
             <connections>
                 <outlet property="confirmButton" destination="7tE-Ac-8Ug" id="ZDE-qJ-o0n"/>


### PR DESCRIPTION
### 추가한 내용
- `NetworkDetector` 싱글톤 객체 추가
    * `wifi`, `cellular`등 현재 연결상태 확인 가능한 객체 추가
    * 해당 객체로 현재 네트워크 연결 상태 판단해서 Toast 보여줌

- `DateInfo` -> `PolarisDate` 데이터로 일원화
    * 현재 `DateInfo`, `PolarisDate` 같은 데이터로 각자 다르게 사용하고 있어서 객체 하나로 통합했습니다.
    * 여러 파라메터를 넘기는 것보다 하나의 객체로 데이터를 전달하는게 더 가독성이 좋아 통일해서 수정했습니다.

- `WeekPickerVC` API 추가되면서 현재 로직에서 ViewModel 추가하고 코드 정리 및 기능 추가
    * `WeekPickerDelegate` 메소드 부분 네이밍 변경했습니다.
        * as-is
            * `apply(year: Int, month: Int, weekNo: Int, weekNoText: String)`
        * to-be
            * `func weekPickerViewController(_ viewController: WeekPickerVC, didSelectedDate date: PolarisDate)`

        * ***변경한 이유*** 
            1. 우선 보통 Delegate, DataSource의 경우 파라메터로 위임받은 객체에게 자기 자신을 넘기게 되는데 이는 위임받은 객체에서 객체를 사용하지 않더라도 어떤 객체가 역할을 위임했는지 알기 위함도 있기 때문이라고 생각해서 수정하게 되었습니다. (+ Apple 컨벤션 같은 느낌이라고 생각합니다!)
            2. `year: Int, month: Int, weekNo: Int, weekNoText: String`을 넘기고 있는데 여러 파라메터를 넘기는 것보다 하나의 데이터모델을 생성해서 넘기는게 가독성도 좋고 유지보수에도 좋아서 수정하게 되었습니다~ (Clean Code에도 파라메터는 적으면 적을수록 좋다고 하더라구요!)
            3. `weekNoText: String`의 경우에는 `WeekPickerVC`의 경우 여러 뷰에서 사용하게 되는데 해당 파라메터의 경우 메인에서만을 사용하기 위한 파라메터 같은 느낌이 들어서 오히려 PolarisDate를 받아서 위임받은 객체에서 새롭게 생성해서 사용하게 수정했습니다.


### 꼭 봐주어야 할 내용
* Journey 추가하는 API 파라메터 `Date` -> `PolarisDate(year, month, weekNo)`으로 수정했습니다.
    * `AddTodoVC` present 할 때, `AddTodoVC`의 `setAddJourneyDate`로 호출해서 추가하고자하는 여정의 날짜를 넣어주면 동작할 것 같습니다

### 확인해야할 내용
* 다음 PR올릴 때, `currentWeekNoOfMonth` 사용하고 있는 부분 확인해서 수정부탁드립니다. 해당 변수는 삭제할 예정

PR 리뷰 환영입니다 🙃