### PR TITLE
[QA] Dongmin

### DIFF
--- a/polaris-ios/polaris-ios/Resources/Extension/UILabel+.swift
+++ b/polaris-ios/polaris-ios/Resources/Extension/UILabel+.swift
@@ -9,7 +9,7 @@ import UIKit
 
 extension UILabel {
     
-    func setPartialBold(originalText: String,boldText: String,fontSize: CGFloat,boldFontSize: CGFloat){
+    func setPartialBold(originalText: String, boldText: String, fontSize: CGFloat, boldFontSize: CGFloat){
         let attributedString = NSMutableAttributedString(string: originalText)
         let font = UIFont.systemFont(ofSize: boldFontSize, weight: .bold)
         self.font = UIFont.systemFont(ofSize: fontSize, weight: .light)

--- a/polaris-ios/polaris-ios/Sources/Enum/Emoticon.swift
+++ b/polaris-ios/polaris-ios/Sources/Enum/Emoticon.swift
@@ -25,7 +25,7 @@ enum Emoticon: String {
         case .expectation:  return UIImage(named: "imgFaceExpectation")
         case .frustrated:   return UIImage(named: "imgFaceFrustrated")
         case .easy:         return UIImage(named: "imgFaceEasy")
-        case .joy:          return UIImage(named: "imgFaceJog")
+        case .joy:          return UIImage(named: "imgFaceJoy")
         case .angry:        return UIImage(named: "imgFaceAngry")
         case .regretful:    return UIImage(named: "imgFaceRegretful")
         case .satisfaction: return UIImage(named: "imgFaceSatisfaction")

--- a/polaris-ios/polaris-ios/Sources/Storyboard/Intro.storyboard
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/Intro.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -265,7 +265,7 @@
                                 </constraints>
                             </view>
                             <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="4" translatesAutoresizingMaskIntoConstraints="NO" id="ELG-xa-jXd">
-                                <rect key="frame" x="-15" y="101" width="172.66666666666666" height="7"/>
+                                <rect key="frame" x="-15" y="101" width="129.66666666666666" height="7"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="7" id="4A3-04-CnI"/>
                                 </constraints>
@@ -413,7 +413,7 @@
                                                                                     <constraint firstAttribute="width" constant="12" id="Pbl-Az-CpJ"/>
                                                                                 </constraints>
                                                                             </imageView>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="6자리 이상이어야 해요." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9XV-xN-TDu">
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="1자리 이상이어야 해요." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9XV-xN-TDu">
                                                                                 <rect key="frame" x="22" y="0.0" width="305" height="14.333333333333334"/>
                                                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="12"/>
                                                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/polaris-ios/polaris-ios/Sources/Storyboard/Retrospect.storyboard
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/Retrospect.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/MainSceneTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/MainSceneTableViewCell.swift
@@ -126,6 +126,7 @@ final class MainSceneTableViewCell: MainTableViewCell {
         self.todoCV.registerCell(cell: MainTodoCVC.self)
         self.todoCV.backgroundColor = .clear
         self.todoCV.decelerationRate = .fast
+        self.todoCV.allowsSelection = false
         self.todoCV.delegate = self
         let layout = self.todoCV.collectionViewLayout as! UICollectionViewFlowLayout
         layout.minimumLineSpacing = 0

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectTableViewCell.swift
@@ -170,7 +170,17 @@ class RetrospectTableViewCell: MainTableViewCell {
     private var capturedStarContainerImage: UIImage? {
         let contentViewAsImage = self.contentView.asImage()
         let screenScale = UIScreen.main.scale
-        let croppedFrame = self.starsContainerView.frame
+        
+        let labelContainerFrame = self.titleLabelContainerView.frame
+        let starsContainerFrame = self.starsContainerView.frame
+        
+        let croppedFrame = CGRect(
+            x: labelContainerFrame.origin.x,
+            y: labelContainerFrame.origin.y,
+            width: labelContainerFrame.width,
+            height: labelContainerFrame.height + starsContainerFrame.height
+        )
+
         let croppedFrameAdjustScale = CGRect(
             x: croppedFrame.origin.x * screenScale,
             y: croppedFrame.origin.y * screenScale,
@@ -187,6 +197,7 @@ class RetrospectTableViewCell: MainTableViewCell {
     private let viewModel = RetrospectViewModel()
     private let disposeBag = DisposeBag()
 
+    @IBOutlet private weak var titleLabelContainerView: UIView!
     @IBOutlet private weak var starsContainerView: UIView!
     
     @IBOutlet private weak var changeImageView: UIImageView!

--- a/polaris-ios/polaris-ios/Sources/ViewController/WeekPickerVC.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/WeekPickerVC.swift
@@ -127,6 +127,19 @@ extension WeekPickerVC: UIPickerViewDelegate {
         33
     }
     
+    func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
+        guard let pickerComponent = PickerComponent(rawValue: component) else { return 0 }
+
+        switch pickerComponent {
+        case .year:
+            return 106
+        case .month:
+            return 70
+        case .weekNo:
+            return 106
+        }
+    }
+    
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
         pickerView.subviews[1].backgroundColor = .mainSky15
         

--- a/polaris-ios/polaris-ios/Sources/ViewModel/Intro/SignupViewModel.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewModel/Intro/SignupViewModel.swift
@@ -117,7 +117,8 @@ final class SignupViewModel {
     }
     
     private func checkNicknameCountValidation(_ nickname: String) {
-        let nicknameCountValidation = nickname.count >= 6
+        let trimmedNickname = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+        let nicknameCountValidation = trimmedNickname.isEmpty == false
         self.nicknameCountValidRelay.accept(nicknameCountValidation)
     }
     

--- a/polaris-ios/polaris-ios/Sources/Xib/TableViewCell/RetrospectTableViewCell.xib
+++ b/polaris-ios/polaris-ios/Sources/Xib/TableViewCell/RetrospectTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -48,10 +48,10 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kac-uY-IID">
-                        <rect key="frame" x="0.0" y="141.66666666666666" width="375" height="463.33333333333337"/>
+                        <rect key="frame" x="0.0" y="113.66666666666666" width="375" height="469.33333333333337"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="MrQ-Hl-e3x">
-                                <rect key="frame" x="93.666666666666671" y="280" width="48.000000000000014" height="75.666666666666686"/>
+                                <rect key="frame" x="93.666666666666671" y="286" width="48.000000000000014" height="75.666666666666686"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="imgGrowth04" translatesAutoresizingMaskIntoConstraints="NO" id="8qo-ZT-Dc9">
                                         <rect key="frame" x="0.0" y="0.0" width="48" height="48"/>
@@ -69,7 +69,7 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="ABc-jY-eAz">
-                                <rect key="frame" x="263.66666666666669" y="280" width="48" height="75.666666666666686"/>
+                                <rect key="frame" x="263.66666666666669" y="286" width="48" height="75.666666666666686"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="imgThanks04" translatesAutoresizingMaskIntoConstraints="NO" id="9QK-xN-hTi">
                                         <rect key="frame" x="0.0" y="0.0" width="48" height="48"/>
@@ -87,7 +87,7 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="3Hw-kj-kFX">
-                                <rect key="frame" x="178.66666666666666" y="214.33333333333334" width="48" height="75.666666666666657"/>
+                                <rect key="frame" x="178.66666666666666" y="220.33333333333329" width="48" height="75.666666666666657"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="imgHealth04" translatesAutoresizingMaskIntoConstraints="NO" id="3JP-PH-kOg">
                                         <rect key="frame" x="0.0" y="0.0" width="48" height="48"/>
@@ -105,7 +105,7 @@
                                 </subviews>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BMa-aI-bZf">
-                                <rect key="frame" x="108" y="42.000000000000007" width="159" height="81.666666666666686"/>
+                                <rect key="frame" x="108" y="47.999999999999979" width="159" height="81.666666666666686"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="Q3c-8Z-dBY">
                                         <rect key="frame" x="0.0" y="6" width="48" height="75.666666666666671"/>
@@ -156,10 +156,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zoT-xB-Pon">
-                                <rect key="frame" x="50.666666666666657" y="123.66666666666666" width="274" height="90.666666666666657"/>
+                                <rect key="frame" x="50.666666666666657" y="129.66666666666669" width="274" height="90.666666666666686"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="Il1-lr-jv8">
-                                        <rect key="frame" x="0.0" y="15" width="57" height="75.666666666666671"/>
+                                        <rect key="frame" x="0.0" y="14.999999999999972" width="57" height="75.666666666666671"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="imgOvercome04" translatesAutoresizingMaskIntoConstraints="NO" id="klh-eR-mTR">
                                                 <rect key="frame" x="4.3333333333333357" y="0.0" width="48" height="48"/>
@@ -177,7 +177,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="9qo-bN-k1D">
-                                        <rect key="frame" x="113" y="-10.999999999999972" width="48" height="75.666666666666671"/>
+                                        <rect key="frame" x="113" y="-11" width="48" height="75.666666666666671"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="imgControl04" translatesAutoresizingMaskIntoConstraints="NO" id="TZZ-u6-KD1">
                                                 <rect key="frame" x="0.0" y="0.0" width="48" height="48"/>
@@ -195,7 +195,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="5XK-79-gqd">
-                                        <rect key="frame" x="226.00000000000003" y="7.6666666666666856" width="47.999999999999972" height="75.666666666666671"/>
+                                        <rect key="frame" x="226.00000000000003" y="7.6666666666666572" width="47.999999999999972" height="75.666666666666671"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="imgRest04" translatesAutoresizingMaskIntoConstraints="NO" id="6E7-61-eae">
                                                 <rect key="frame" x="0.0" y="0.0" width="48" height="48"/>
@@ -227,7 +227,7 @@
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="6J7-TP-k71">
-                                <rect key="frame" x="198.66666666666666" y="345.66666666666663" width="48" height="75.666666666666686"/>
+                                <rect key="frame" x="198.66666666666666" y="351.66666666666663" width="48" height="75.666666666666686"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="imgChallenge04" translatesAutoresizingMaskIntoConstraints="NO" id="1za-9I-vGW">
                                         <rect key="frame" x="0.0" y="0.0" width="48" height="48"/>
@@ -252,7 +252,7 @@
                             <constraint firstAttribute="bottom" secondItem="6J7-TP-k71" secondAttribute="bottom" constant="42" id="M1X-oa-pXz"/>
                             <constraint firstItem="MrQ-Hl-e3x" firstAttribute="centerX" secondItem="kac-uY-IID" secondAttribute="centerX" constant="-70" id="V52-OQ-U3O"/>
                             <constraint firstItem="6J7-TP-k71" firstAttribute="centerX" secondItem="kac-uY-IID" secondAttribute="centerX" constant="35" id="aF0-nz-gOq"/>
-                            <constraint firstItem="BMa-aI-bZf" firstAttribute="top" secondItem="kac-uY-IID" secondAttribute="top" constant="42" id="jvE-rG-uaH"/>
+                            <constraint firstItem="BMa-aI-bZf" firstAttribute="top" secondItem="kac-uY-IID" secondAttribute="top" constant="48" id="jvE-rG-uaH"/>
                             <constraint firstItem="BMa-aI-bZf" firstAttribute="centerX" secondItem="kac-uY-IID" secondAttribute="centerX" id="kQi-n3-8d8"/>
                             <constraint firstItem="ABc-jY-eAz" firstAttribute="centerX" secondItem="kac-uY-IID" secondAttribute="centerX" constant="100" id="qbe-nR-Zih"/>
                             <constraint firstItem="zoT-xB-Pon" firstAttribute="top" secondItem="BMa-aI-bZf" secondAttribute="bottom" id="qsb-Zb-mOb"/>
@@ -303,7 +303,7 @@
                     <constraint firstAttribute="trailing" secondItem="kac-uY-IID" secondAttribute="trailing" id="j8M-DM-MZQ"/>
                     <constraint firstItem="ZIV-Sq-fos" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="r07-St-L12"/>
                     <constraint firstItem="ZIV-Sq-fos" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="sSo-Y2-cap"/>
-                    <constraint firstItem="kac-uY-IID" firstAttribute="top" secondItem="b7B-9a-a4F" secondAttribute="bottom" constant="28" id="yW1-Bi-5jr"/>
+                    <constraint firstItem="kac-uY-IID" firstAttribute="top" secondItem="b7B-9a-a4F" secondAttribute="bottom" id="yW1-Bi-5jr"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>

--- a/polaris-ios/polaris-ios/Sources/Xib/TableViewCell/RetrospectTableViewCell.xib
+++ b/polaris-ios/polaris-ios/Sources/Xib/TableViewCell/RetrospectTableViewCell.xib
@@ -35,20 +35,35 @@
                             <constraint firstAttribute="trailing" secondItem="Wz4-fM-JkJ" secondAttribute="trailing" constant="8" id="vtI-Tm-EqJ"/>
                         </constraints>
                     </view>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="내가 찾은 별로" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oTZ-hh-uJ7">
-                        <rect key="frame" x="24" y="59.999999999999993" width="327" height="27.666666666666664"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="23"/>
-                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="많이 찾은 별이 더 밝게 빛나요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b7B-9a-a4F">
-                        <rect key="frame" x="24" y="95.666666666666671" width="175.66666666666666" height="18"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7NO-4t-Ss9">
+                        <rect key="frame" x="0.0" y="60" width="375" height="52.666666666666657"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="내가 찾은 별로" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oTZ-hh-uJ7">
+                                <rect key="frame" x="24" y="0.0" width="327" height="27.666666666666668"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="23"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="많이 찾은 별이 더 밝게 빛나요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b7B-9a-a4F">
+                                <rect key="frame" x="24" y="34.666666666666671" width="327" height="18"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="b7B-9a-a4F" secondAttribute="bottom" id="G5v-2G-Qx7"/>
+                            <constraint firstItem="oTZ-hh-uJ7" firstAttribute="leading" secondItem="7NO-4t-Ss9" secondAttribute="leading" constant="24" id="JaR-ON-rtB"/>
+                            <constraint firstAttribute="trailing" secondItem="b7B-9a-a4F" secondAttribute="trailing" constant="24" id="MSC-MI-rsn"/>
+                            <constraint firstItem="b7B-9a-a4F" firstAttribute="leading" secondItem="7NO-4t-Ss9" secondAttribute="leading" constant="24" id="ioP-fX-4iG"/>
+                            <constraint firstItem="oTZ-hh-uJ7" firstAttribute="top" secondItem="7NO-4t-Ss9" secondAttribute="top" id="pRU-mW-zIG"/>
+                            <constraint firstItem="b7B-9a-a4F" firstAttribute="top" secondItem="oTZ-hh-uJ7" secondAttribute="bottom" constant="7" id="uoc-uf-qxH"/>
+                            <constraint firstAttribute="trailing" secondItem="oTZ-hh-uJ7" secondAttribute="trailing" constant="24" id="ybP-b7-5J8"/>
+                        </constraints>
+                    </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kac-uY-IID">
-                        <rect key="frame" x="0.0" y="113.66666666666666" width="375" height="469.33333333333337"/>
+                        <rect key="frame" x="0.0" y="112.66666666666666" width="375" height="469.33333333333337"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="MrQ-Hl-e3x">
                                 <rect key="frame" x="93.666666666666671" y="286" width="48.000000000000014" height="75.666666666666686"/>
@@ -290,20 +305,18 @@
                     <constraint firstAttribute="bottom" secondItem="nhp-Rp-FoC" secondAttribute="bottom" constant="48" id="4p4-By-eMw"/>
                     <constraint firstAttribute="bottom" secondItem="JoQ-J4-Tyb" secondAttribute="bottom" id="76U-gq-gKj"/>
                     <constraint firstItem="JoQ-J4-Tyb" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="9uN-KM-r33"/>
-                    <constraint firstItem="b7B-9a-a4F" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="24" id="C4E-Mg-jbW"/>
+                    <constraint firstItem="7NO-4t-Ss9" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="E22-GC-ZPT"/>
                     <constraint firstItem="kac-uY-IID" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="G5b-ig-0Bq"/>
-                    <constraint firstAttribute="trailing" secondItem="oTZ-hh-uJ7" secondAttribute="trailing" constant="24" id="TM4-7O-cKK"/>
                     <constraint firstItem="JoQ-J4-Tyb" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="UEO-zK-vGq"/>
                     <constraint firstItem="nhp-Rp-FoC" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="ZF1-uz-cH2"/>
+                    <constraint firstItem="kac-uY-IID" firstAttribute="top" secondItem="7NO-4t-Ss9" secondAttribute="bottom" id="aGz-XU-0zH"/>
                     <constraint firstAttribute="trailing" secondItem="ZIV-Sq-fos" secondAttribute="trailing" id="apM-PB-tX5"/>
                     <constraint firstAttribute="trailing" secondItem="JoQ-J4-Tyb" secondAttribute="trailing" id="ayK-Tf-OZc"/>
-                    <constraint firstItem="b7B-9a-a4F" firstAttribute="top" secondItem="oTZ-hh-uJ7" secondAttribute="bottom" constant="8" id="cbI-gu-rLq"/>
-                    <constraint firstItem="oTZ-hh-uJ7" firstAttribute="top" secondItem="ZIV-Sq-fos" secondAttribute="bottom" id="dUi-Af-f32"/>
-                    <constraint firstItem="oTZ-hh-uJ7" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="24" id="ea4-7Y-qHh"/>
                     <constraint firstAttribute="trailing" secondItem="kac-uY-IID" secondAttribute="trailing" id="j8M-DM-MZQ"/>
                     <constraint firstItem="ZIV-Sq-fos" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="r07-St-L12"/>
                     <constraint firstItem="ZIV-Sq-fos" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="sSo-Y2-cap"/>
-                    <constraint firstItem="kac-uY-IID" firstAttribute="top" secondItem="b7B-9a-a4F" secondAttribute="bottom" id="yW1-Bi-5jr"/>
+                    <constraint firstAttribute="trailing" secondItem="7NO-4t-Ss9" secondAttribute="trailing" id="sU4-OF-fyd"/>
+                    <constraint firstItem="7NO-4t-Ss9" firstAttribute="top" secondItem="ZIV-Sq-fos" secondAttribute="bottom" id="yDL-ET-EDQ"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
@@ -331,6 +344,7 @@
                 <outlet property="thanksImageView" destination="9QK-xN-hTi" id="8ba-Fq-ak1"/>
                 <outlet property="thanksStarConstraint" destination="4Tw-zD-3tf" id="jhU-IH-ECc"/>
                 <outlet property="titleLabel" destination="oTZ-hh-uJ7" id="JaI-tB-7eD"/>
+                <outlet property="titleLabelContainerView" destination="7NO-4t-Ss9" id="OBV-xK-gPt"/>
             </connections>
             <point key="canvasLocation" x="138.40000000000001" y="152.95566502463055"/>
         </tableViewCell>


### PR DESCRIPTION
### 수정 내용

- 별 리포트 공유 시 이미지에 텍스트 포함
    * as-is
        * 지금은 별 부분만 캡쳐
    * to-be
        * 별 부분  + 라벨 부분 캡쳐

- 회원 가입 시, 별명 validation 로직 수정
    * as-is
        * 6자리 이상만 가입 가능
    * to-be
        * 제일 앞, 뒤 공백 제외하고 1자리 이상인 경우 가입 가능

- `WeekPickerView`에서 라벨이 길어질 시, 넓이가 작은 기종에서 ...으로 표시되는 문제 수정 
- `MainSceneTableViewCell`에서 `TodoCV` 영역이 선택되어 하이라이트되는 문제 수정
- `Emoticon` enum의 `Joy`인 경우 Image Asset 이름 잘못 설정한 부분 수정


### 관련 이슈
이슈 번호 : #47 