### PR TITLE
[QA] Dongmin

### DIFF
--- a/polaris-ios/polaris-ios.xcodeproj/project.pbxproj
+++ b/polaris-ios/polaris-ios.xcodeproj/project.pbxproj
@@ -2846,7 +2846,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = AKW8XUH283;
 				INFOPLIST_FILE = "polaris-ios/polaris-ios.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/polaris-ios/polaris-ios/Sources/Storyboard/Intro.storyboard
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/Intro.storyboard
@@ -400,7 +400,7 @@
                                                                     <constraint firstAttribute="height" constant="53" id="AOX-N8-Gof"/>
                                                                 </constraints>
                                                             </view>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Fjw-tp-9K8">
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="Fjw-tp-9K8">
                                                                 <rect key="frame" x="0.0" y="99.999999999999972" width="327" height="14.333333333333329"/>
                                                                 <subviews>
                                                                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KQe-f5-kgV">
@@ -413,7 +413,7 @@
                                                                                     <constraint firstAttribute="width" constant="12" id="Pbl-Az-CpJ"/>
                                                                                 </constraints>
                                                                             </imageView>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="1자리 이상이어야 해요." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9XV-xN-TDu">
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="최소 한 글자 이상이어야 해요." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9XV-xN-TDu">
                                                                                 <rect key="frame" x="22" y="0.0" width="305" height="14.333333333333334"/>
                                                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="12"/>
                                                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -428,6 +428,33 @@
                                                                             <constraint firstItem="9XV-xN-TDu" firstAttribute="top" secondItem="KQe-f5-kgV" secondAttribute="top" id="Hz0-ag-f2c"/>
                                                                             <constraint firstItem="uZ2-Yb-6v4" firstAttribute="centerY" secondItem="KQe-f5-kgV" secondAttribute="centerY" id="MxG-aC-Z30"/>
                                                                             <constraint firstItem="9XV-xN-TDu" firstAttribute="leading" secondItem="uZ2-Yb-6v4" secondAttribute="trailing" constant="5" id="VS6-WI-dFR"/>
+                                                                        </constraints>
+                                                                    </view>
+                                                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mnd-tN-3ex">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="327" height="14.333333333333334"/>
+                                                                        <subviews>
+                                                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icnError" translatesAutoresizingMaskIntoConstraints="NO" id="0HY-bg-Lm6">
+                                                                                <rect key="frame" x="5" y="1.3333333333333712" width="12" height="12"/>
+                                                                                <constraints>
+                                                                                    <constraint firstAttribute="width" constant="12" id="1bU-Ml-R9g"/>
+                                                                                    <constraint firstAttribute="height" constant="12" id="YkP-tM-Adr"/>
+                                                                                </constraints>
+                                                                            </imageView>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="이모지나 문장부호는 포함될 수 없어요." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EBN-lj-fXD">
+                                                                                <rect key="frame" x="22" y="0.0" width="305" height="14.333333333333334"/>
+                                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="12"/>
+                                                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                                <nil key="highlightedColor"/>
+                                                                            </label>
+                                                                        </subviews>
+                                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="trailing" secondItem="EBN-lj-fXD" secondAttribute="trailing" id="3fA-NH-MdM"/>
+                                                                            <constraint firstAttribute="bottom" secondItem="EBN-lj-fXD" secondAttribute="bottom" id="DZj-qT-d7b"/>
+                                                                            <constraint firstItem="EBN-lj-fXD" firstAttribute="top" secondItem="Mnd-tN-3ex" secondAttribute="top" id="Ffa-OE-Nch"/>
+                                                                            <constraint firstItem="0HY-bg-Lm6" firstAttribute="leading" secondItem="Mnd-tN-3ex" secondAttribute="leading" constant="5" id="b3F-cI-fkW"/>
+                                                                            <constraint firstItem="EBN-lj-fXD" firstAttribute="leading" secondItem="0HY-bg-Lm6" secondAttribute="trailing" constant="5" id="rDr-gO-HsO"/>
+                                                                            <constraint firstItem="0HY-bg-Lm6" firstAttribute="centerY" secondItem="Mnd-tN-3ex" secondAttribute="centerY" id="tpE-7R-Wwb"/>
                                                                         </constraints>
                                                                     </view>
                                                                 </subviews>
@@ -688,11 +715,13 @@
                         <outlet property="idFormatValidateView" destination="xTs-H1-tjc" id="kNu-ve-SPO"/>
                         <outlet property="idInputContainerView" destination="q9t-Rx-gRg" id="j3F-9c-0yv"/>
                         <outlet property="idTextFieldContainerView" destination="Zac-Wx-QZW" id="Wu6-sz-3Az"/>
+                        <outlet property="nicknameCountValidateImageView" destination="uZ2-Yb-6v4" id="4rH-ZQ-BTR"/>
+                        <outlet property="nicknameCountValidateView" destination="KQe-f5-kgV" id="2HU-dS-DQc"/>
                         <outlet property="nicknameDescriptionStackView" destination="d5a-Tl-cSD" id="jNA-Wx-Hmr"/>
+                        <outlet property="nicknameFormatValidateImageView" destination="0HY-bg-Lm6" id="SWb-Ml-MQn"/>
+                        <outlet property="nicknameFormatValidateView" destination="Mnd-tN-3ex" id="0zF-4W-f82"/>
                         <outlet property="nicknameInputContainerView" destination="0A0-NZ-trE" id="EnJ-KI-Lja"/>
                         <outlet property="nicknameTextFieldContainerView" destination="vJa-ZP-YDg" id="uvp-eX-QC0"/>
-                        <outlet property="nicknameValidateImageView" destination="uZ2-Yb-6v4" id="4rH-ZQ-BTR"/>
-                        <outlet property="nicknameValidateView" destination="KQe-f5-kgV" id="2HU-dS-DQc"/>
                         <outlet property="pwCountValidateImageView" destination="MDT-S7-WSx" id="p0u-qI-lwg"/>
                         <outlet property="pwCountValidateView" destination="2v1-Pj-5u4" id="ICV-ns-9qt"/>
                         <outlet property="pwDescriptionStackView" destination="evB-BF-ptj" id="FjG-Tu-kbX"/>

--- a/polaris-ios/polaris-ios/Sources/ViewController/Intro/SignupVC.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/Intro/SignupVC.swift
@@ -70,6 +70,7 @@ final class SignupVC: UIViewController {
             .subscribe(onNext: { [weak self] step in
                 guard let self = self else { return }
                 
+                self.becomeFirstResponder(asState: step)
                 self.updateUI(as: step)
             })
             .disposed(by: self.disposeBag)
@@ -152,6 +153,16 @@ final class SignupVC: UIViewController {
         
         guard state != .firstStep else { return }
         UIView.animate(withDuration: 0.35, delay: 0, options: [.curveEaseInOut]) { self.view.layoutIfNeeded() }
+    }
+    
+    private func becomeFirstResponder(asState state: InputOptions) {
+        if state == .firstStep {
+            self.idTextFieldView?.becomeKeyboardFirstResponder()
+        } else if state == .secondStep {
+            self.pwTextFieldView?.becomeKeyboardFirstResponder()
+        } else if state == .lastStep {
+            self.nicknameTextFieldView?.becomeKeyboardFirstResponder()
+        }
     }
     
     private func updateValidationViewHiddenState(state: InputOptions, input: String) {

--- a/polaris-ios/polaris-ios/Sources/ViewController/Intro/SignupVC.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/Intro/SignupVC.swift
@@ -277,7 +277,13 @@ extension SignupVC: TermsOfServiceDelegate {
         self.viewModel.requestSignup { [weak self] in
             self?.stopLoadingIndicator()
             guard let mainVC = MainVC.instantiateFromStoryboard(StoryboardName.main) else { return }
-            UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.rootViewController = mainVC
+            let navigationController = UINavigationController(rootViewController: mainVC)
+            navigationController.setNavigationBarHidden(true, animated: false)
+            UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.rootViewController = navigationController
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                mainVC.scrollToMainSceneCell(animated: false)
+            }
         }
     }
     

--- a/polaris-ios/polaris-ios/Sources/ViewController/Intro/SignupVC.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/Intro/SignupVC.swift
@@ -113,7 +113,15 @@ final class SignupVC: UIViewController {
             .distinctUntilChanged()
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { validation in
-                self.nicknameValidateImageView.image = validation ? #imageLiteral(resourceName: "icnPass") : #imageLiteral(resourceName: "icnError")
+                self.nicknameCountValidateImageView.image = validation ? #imageLiteral(resourceName: "icnPass") : #imageLiteral(resourceName: "icnError")
+            })
+            .disposed(by: self.disposeBag)
+        
+        self.viewModel.nicknameFormatValidRelay
+            .distinctUntilChanged()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { validation in
+                self.nicknameFormatValidateImageView.image = validation ? #imageLiteral(resourceName: "icnPass") : #imageLiteral(resourceName: "icnError")
             })
             .disposed(by: self.disposeBag)
     }
@@ -167,13 +175,14 @@ final class SignupVC: UIViewController {
     
     private func updateValidationViewHiddenState(state: InputOptions, input: String) {
         if state == .id {
-            self.idFormatValidateView.isHidden     = input.isEmpty
+            self.idFormatValidateView.isHidden = input.isEmpty
             self.idDuplicatedValidateView.isHidden = input.isEmpty
         } else if state == .pw {
-            self.pwFormatValidateView.isHidden      = input.isEmpty
-            self.pwCountValidateView.isHidden      = input.isEmpty
+            self.pwFormatValidateView.isHidden = input.isEmpty
+            self.pwCountValidateView.isHidden = input.isEmpty
         } else {
-            self.nicknameValidateView.isHidden     = input.isEmpty
+            self.nicknameCountValidateView.isHidden = input.isEmpty
+            self.nicknameFormatValidateView.isHidden = input.isEmpty
         }
         
         UIView.animate(withDuration: 0.3) { self.view.layoutIfNeeded() }
@@ -209,8 +218,10 @@ final class SignupVC: UIViewController {
     @IBOutlet private weak var nicknameInputContainerView: UIView!
     @IBOutlet private weak var nicknameTextFieldContainerView: UIView!
     private var nicknameTextFieldView: PolarisMarginTextField? = UIView.fromNib()
-    @IBOutlet private weak var nicknameValidateView: UIView!
-    @IBOutlet private weak var nicknameValidateImageView: UIImageView!
+    @IBOutlet private weak var nicknameCountValidateView: UIView!
+    @IBOutlet private weak var nicknameCountValidateImageView: UIImageView!
+    @IBOutlet private weak var nicknameFormatValidateView: UIView!
+    @IBOutlet private weak var nicknameFormatValidateImageView: UIImageView!
     
 }
 

--- a/polaris-ios/polaris-ios/Sources/ViewModel/Intro/LoginViewModel.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewModel/Intro/LoginViewModel.swift
@@ -38,13 +38,13 @@ final class LoginViewModel {
         self.loadingSubject.onNext(true)
         let userAPI = UserAPI.auth(email: id, password: password)
         NetworkManager.request(apiType: userAPI)
-            .subscribe(onSuccess: { (authModel: AuthModel) in
+            .subscribe(onSuccess: { [weak self] (authModel: AuthModel) in
                 PolarisUserManager.shared.updateAuthToken(authModel.accessToken, authModel.refreshToken)
-                self.completeLoginSubject.onNext(())
-                self.loadingSubject.onNext(false)
-            }, onFailure: { error in
+                self?.completeLoginSubject.onNext(())
+                self?.loadingSubject.onNext(false)
+            }, onFailure: { [weak self] error in
                 print(error.localizedDescription)
-                self.loadingSubject.onNext(false)
+                self?.loadingSubject.onNext(false)
             }).disposed(by: self.disposeBag)
     }
     

--- a/polaris-ios/polaris-ios/Sources/ViewModel/Intro/SignupViewModel.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewModel/Intro/SignupViewModel.swift
@@ -18,11 +18,12 @@ final class SignupViewModel {
     let pwSubject       = BehaviorSubject<String>(value: "")
     let nicknameSubject = BehaviorSubject<String>(value: "")
     
-    let idDuplicatedValidRelay  = BehaviorRelay<Bool>(value: false)
-    let idFormatValidRelay      = BehaviorRelay<Bool>(value: false)
-    let pwCountValidRelay       = BehaviorRelay<Bool>(value: false)
-    let pwFormatValidRelay      = BehaviorRelay<Bool>(value: false)
-    let nicknameCountValidRelay = BehaviorRelay<Bool>(value: false)
+    let idDuplicatedValidRelay   = BehaviorRelay<Bool>(value: false)
+    let idFormatValidRelay       = BehaviorRelay<Bool>(value: false)
+    let pwCountValidRelay        = BehaviorRelay<Bool>(value: false)
+    let pwFormatValidRelay       = BehaviorRelay<Bool>(value: false)
+    let nicknameCountValidRelay  = BehaviorRelay<Bool>(value: false)
+    let nicknameFormatValidRelay = BehaviorRelay<Bool>(value: false)
     
     let completeSignupSubject   = BehaviorSubject<Bool>(value: false)
     
@@ -48,6 +49,7 @@ final class SignupViewModel {
         
         self.nicknameSubject
             .subscribe(onNext: { [weak self] nickname in
+                self?.checkNicknameFormatValidation(nickname)
                 self?.checkNicknameCountValidation(nickname)
             })
             .disposed(by: self.disposeBag)
@@ -122,6 +124,18 @@ final class SignupViewModel {
         self.nicknameCountValidRelay.accept(nicknameCountValidation)
     }
     
+    // 닉네임에 이모지, 특수 부호가 포함된 경우 제한
+    private func checkNicknameFormatValidation(_ nickname: String) {
+        let regex = try? NSRegularExpression(pattern: "^[0-9a-zA-Z가-힣ㄱ-ㅎㅏ-ㅣ\\s]*$", options: .caseInsensitive)
+        let range = NSRange(location: 0, length: nickname.count)
+        
+        if let _ = regex?.firstMatch(in: nickname, options: .reportCompletion, range: range) {
+            self.nicknameFormatValidRelay.accept(true)
+        } else {
+            self.nicknameFormatValidRelay.accept(false)
+        }
+    }
+    
     private var isProcessableFirstStep: Bool {
         return self.idDuplicatedValidRelay.value == true && self.idFormatValidRelay.value == true
     }
@@ -133,6 +147,7 @@ final class SignupViewModel {
     
     private var isProcessableLastStep: Bool {
         return self.isProcessableSecondStep == true && self.nicknameCountValidRelay.value == true
+            && self.nicknameFormatValidRelay.value == true
     }
     
     private var disposeBag = DisposeBag()


### PR DESCRIPTION
### PR 내용
- 회원 가입 시 UX 개선
    * as-is
        * 기존에는 이메일 입력 -> 비밀번호 입력 -> 닉네임 입력 각 단계로 넘어갈 시, textfield resignFirstResponder 됨
        * 사용자가 새롭게 입력하는 UITextField 선택 필요

    * to-be
        * 각각 한단계씩 입력할 때마다, 이전의 TextField는 resignFirstResponder 후, becomeFirstResponder 로직 실행

- 회원 가입 시, 닉네임 입력 format Validation 추가
    * as-is
        * 기존에는 글자수 제한만 존재
     
    * to-be
        * 닉네임 입력 시, 이모지 및 특수부호 입력 시 제한
        * UI에도 글자 및 포맷에 관한 Validation 문구 추가

- 회원 가입 후, 자동 로그인 로직 추가
    * as-is
        * 기존에는 회원 가입 후, 자동으로 MainVC로 넘어갈 때 토큰 값을 업데이트 해주지 않음
    
    * to-be
        * 회원 가입 후, 로그인 API 호출해서 토큰 값 업데이트 로직 추가