### PR TITLE
[Refactor, QA] AddTodo 리팩토링 및 여정 추가 QA

### DIFF
--- a/polaris-ios/polaris-ios.xcodeproj/project.pbxproj
+++ b/polaris-ios/polaris-ios.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		343EE86C1BBB3A61832CF112 /* Pods_polaris_ios_Polaris_Beta.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B35230A1FF0651B0EB66A598 /* Pods_polaris_ios_Polaris_Beta.framework */; };
 		7EB0D09D416E16BB73D26E01 /* Pods_polaris_ios_Polaris_Alpha.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 19D1126DBB53127CC126B3AD /* Pods_polaris_ios_Polaris_Alpha.framework */; };
+		CE01725327F04AA600EB1C50 /* AddTodoViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE01725227F04AA600EB1C50 /* AddTodoViewFactory.swift */; };
+		CE01725427F04AA700EB1C50 /* AddTodoViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE01725227F04AA600EB1C50 /* AddTodoViewFactory.swift */; };
+		CE01725527F04AA700EB1C50 /* AddTodoViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE01725227F04AA600EB1C50 /* AddTodoViewFactory.swift */; };
 		CE04A036262340D1007C98E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE04A035262340D1007C98E2 /* AppDelegate.swift */; };
 		CE04A038262340D1007C98E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE04A037262340D1007C98E2 /* SceneDelegate.swift */; };
 		CE04A03D262340D1007C98E2 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE04A03B262340D1007C98E2 /* Main.storyboard */; };
@@ -782,6 +785,7 @@
 		62A763CE321F34C429250864 /* Pods_polaris_ios_Polaris.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_polaris_ios_Polaris.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B9070CF72A6FB1E8ED31409 /* Pods-polaris-ios-Polaris Dev.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-polaris-ios-Polaris Dev.beta.xcconfig"; path = "Target Support Files/Pods-polaris-ios-Polaris Dev/Pods-polaris-ios-Polaris Dev.beta.xcconfig"; sourceTree = "<group>"; };
 		B35230A1FF0651B0EB66A598 /* Pods_polaris_ios_Polaris_Beta.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_polaris_ios_Polaris_Beta.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CE01725227F04AA600EB1C50 /* AddTodoViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTodoViewFactory.swift; sourceTree = "<group>"; };
 		CE04A032262340D1007C98E2 /* Polaris.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Polaris.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE04A035262340D1007C98E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CE04A037262340D1007C98E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -1478,6 +1482,7 @@
 				CEEE5742262A955D00C39358 /* PolarisUserManager.swift */,
 				CE574DBA26357CBC0046D20A /* PolarisToastManager.swift */,
 				CE3102BB27E5BF5D00CE0305 /* MainSceneDateSelector.swift */,
+				CE01725227F04AA600EB1C50 /* AddTodoViewFactory.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -2177,6 +2182,7 @@
 				CEEE5766262ADBA200C39358 /* PolarisButton.swift in Sources */,
 				CEEE5782262C018F00C39358 /* AddTodoViewModel.swift in Sources */,
 				CE5342D027E650DF0082F570 /* TodoCategory.swift in Sources */,
+				CE01725327F04AA600EB1C50 /* AddTodoViewFactory.swift in Sources */,
 				ECA461972782868A00FBD425 /* LookBackFifthTableViewCell.swift in Sources */,
 				CEB9EA6C27AAAD200017F59B /* WeekRepository.swift in Sources */,
 				CEEE5786262C112E00C39358 /* AddTodoFixOnTopTableViewCell.swift in Sources */,
@@ -2367,6 +2373,7 @@
 				CE2952F92687A0A500E21871 /* AddTodoViewModel.swift in Sources */,
 				CE2952FA2687A0A500E21871 /* AddTodoFixOnTopTableViewCell.swift in Sources */,
 				CE5342D127E650E20082F570 /* TodoCategory.swift in Sources */,
+				CE01725427F04AA700EB1C50 /* AddTodoViewFactory.swift in Sources */,
 				ECA461982782868A00FBD425 /* LookBackFifthTableViewCell.swift in Sources */,
 				CEB9EA6D27AAAD200017F59B /* WeekRepository.swift in Sources */,
 				CED6B6DC26CAC1F900D37647 /* SuccessModel.swift in Sources */,
@@ -2557,6 +2564,7 @@
 				CE43D02C26613D66003126F2 /* AddTodoViewModel.swift in Sources */,
 				CE43D02D26613D66003126F2 /* AddTodoFixOnTopTableViewCell.swift in Sources */,
 				CE5342D227E650E20082F570 /* TodoCategory.swift in Sources */,
+				CE01725527F04AA700EB1C50 /* AddTodoViewFactory.swift in Sources */,
 				ECA461992782868A00FBD425 /* LookBackFifthTableViewCell.swift in Sources */,
 				CEB9EA6E27AAAD200017F59B /* WeekRepository.swift in Sources */,
 				CED6B6DD26CAC1F900D37647 /* SuccessModel.swift in Sources */,

--- a/polaris-ios/polaris-ios/Resources/Extension/UIView+.swift
+++ b/polaris-ios/polaris-ios/Resources/Extension/UIView+.swift
@@ -39,6 +39,11 @@ extension UIView {
         return nib.first as? T
     }
     
+    func addCometAnimation(cometCount: Int = 3) {
+        guard cometCount >= 0 else { return }
+        (0..<cometCount).forEach { _ in self.startCometAnimation() }
+    }
+    
     func showCrossDissolve(duration: TimeInterval = 0.2, completion: (() -> Void)? = nil) {
         self.isHidden = false
         self.alpha    = 0
@@ -105,6 +110,41 @@ extension UIView {
         return renderer.image { renderImageContext in
             self.layer.render(in: renderImageContext.cgContext)
         }
+    }
+    
+    private func startCometAnimation() {
+        guard let cometImageView = self.makeRandomCometImageView() else { return }
+        self.addSubview(cometImageView)
+        
+        let duration: Double = Double(Int.random(in: 15...60)) / 10.0
+        let restDistance: CGFloat = 100
+        
+        UIView.animate(withDuration: duration, delay: 0, options: .curveEaseIn, animations: {
+            cometImageView.transform = CGAffineTransform(
+                translationX: -DeviceInfo.screenWidth - restDistance,
+                y: DeviceInfo.screenWidth + restDistance
+            )
+        }, completion: { [weak self] _ in
+            cometImageView.removeFromSuperview()
+            self?.startCometAnimation()
+        })
+    }
+    
+    private func makeRandomCometImageView() -> UIImageView? {
+        guard let cometType = ShootingComet.allCases.randomElement() else { return nil }
+        
+        let screenWidth = DeviceInfo.screenWidth
+        let screenHeight = DeviceInfo.screenHeight
+        let yPosition = CGFloat(Int.random(in: 0...(Int(screenHeight) / 2)))
+        
+        let cometImageView = UIImageView(image: cometType.starImage)
+        cometImageView.frame = CGRect(
+            x: screenWidth,
+            y: yPosition,
+            width: cometType.size,
+            height: cometType.size
+        )
+        return cometImageView
     }
     
 }

--- a/polaris-ios/polaris-ios/Sources/Manager/AddTodoViewFactory.swift
+++ b/polaris-ios/polaris-ios/Sources/Manager/AddTodoViewFactory.swift
@@ -1,0 +1,24 @@
+//
+//  AddTodoViewFactory.swift
+//  polaris-ios
+//
+//  Created by Dongmin on 2022/03/27.
+//
+
+import Foundation
+
+struct AddTodoViewMakingParameter {
+    let mode: AddTodoVC.AddMode
+    var delegate: AddTodoViewControllerDelegate?
+}
+
+enum AddTodoViewFactory {
+    
+    static func makeAddTodoViewController(param: AddTodoViewMakingParameter) -> AddTodoVC? {
+        let addTodoView = AddTodoVC.instantiateFromStoryboard(StoryboardName.addTodo)
+        addTodoView?.delegate = param.delegate
+        addTodoView?.setAddMode(param.mode)
+        return addTodoView
+    }
+    
+}

--- a/polaris-ios/polaris-ios/Sources/Protocol/AddTodoTableViewCellProtocol.swift
+++ b/polaris-ios/polaris-ios/Sources/Protocol/AddTodoTableViewCellProtocol.swift
@@ -13,12 +13,12 @@ protocol AddTodoTableViewCellProtocol: UITableViewCell {
     static var cellHeight: CGFloat { get }
     var delegate: AddTodoTableViewCellDelegate? { get set }
     
-    func configure(by addOptions: AddTodoVC.AddOptions, date: Date?)
+    func configure(by addMode: AddTodoVC.AddMode, date: Date?)
 }
 
 class AddTodoTableViewCell: UITableViewCell, AddTodoTableViewCellProtocol {
     class var cellHeight: CGFloat { return 0 }
     weak var delegate: AddTodoTableViewCellDelegate?
     
-    func configure(by addOptions: AddTodoVC.AddOptions, date: Date? = nil) { }
+    func configure(by addMode: AddTodoVC.AddMode, date: Date? = nil) { }
 }

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoDayTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoDayTableViewCell.swift
@@ -13,14 +13,16 @@ protocol AddTodoDayTableViewCellDelegate: AddTodoTableViewCellDelegate {
 }
 
 class AddTodoDayTableViewCell: AddTodoTableViewCell {
+    
     override class var cellHeight: CGFloat {
         let labelHeight: CGFloat = 17
         let spacing: CGFloat     = 15
         return (verticalInset * 2) + dayCellHeight + spacing + labelHeight
     }
     
-    override weak var delegate: AddTodoTableViewCellDelegate? { didSet { self._delegate = delegate as? AddTodoDayTableViewCellDelegate } }
-    weak var _delegate: AddTodoDayTableViewCellDelegate?
+    override weak var delegate: AddTodoTableViewCellDelegate? {
+        didSet { self._delegate = delegate as? AddTodoDayTableViewCellDelegate }
+    }
     
     // MARK: - Life Cycle
     override func awakeFromNib() {
@@ -30,7 +32,20 @@ class AddTodoDayTableViewCell: AddTodoTableViewCell {
         self.bindCollectionView()
     }
     
-    func updateSelectDate(_ date: Date) {
+    override func configure(by addMode: AddTodoVC.AddMode, date: Date? = nil) {
+        super.configure(by: addMode, date: date)
+        
+        switch addMode {
+        case .editTodo(let todo):
+            guard let todoDate = todo.date?.convertToDate()?.normalizedDate else { return }
+            self.updateSelectDate(todoDate)
+            
+        default:
+            break
+        }
+    }
+    
+    private func updateSelectDate(_ date: Date) {
         guard let selectedDateIndex = self.viewModel.datesRelay.value.firstIndex(of: date) else { return }
         let indexPath = IndexPath(item: selectedDateIndex, section: 0)
         self.collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
@@ -79,6 +94,8 @@ class AddTodoDayTableViewCell: AddTodoTableViewCell {
                 self._delegate?.addTodoDayTableViewCell(self, didSelectDate: selectedDate)
             }).disposed(by: self.disposeBag)
     }
+    
+    private weak var _delegate: AddTodoDayTableViewCellDelegate?
     
     private static let horizontalInset: CGFloat     = 23
     private static let verticalInset: CGFloat       = 10

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoDeleteJourneyTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoDeleteJourneyTableViewCell.swift
@@ -22,12 +22,14 @@ class AddTodoDeleteJourneyTableViewCell: AddTodoTableViewCell {
     override var delegate: AddTodoTableViewCellDelegate? {
         didSet { self._delegate = self.delegate as? AddTodoDeleteJourneyTableViewCellDelegate }
     }
-    
-    weak var _delegate: AddTodoDeleteJourneyTableViewCellDelegate?
 
     override func awakeFromNib() {
         super.awakeFromNib()
         self.bindButtons()
+    }
+    
+    override func configure(by addMode: AddTodoVC.AddMode, date: Date? = nil) {
+        super.configure(by: addMode, date: date)
     }
     
     private func bindButtons() {
@@ -38,6 +40,8 @@ class AddTodoDeleteJourneyTableViewCell: AddTodoTableViewCell {
                 self._delegate?.addTodoDeleteJourneyTableViewCellDidTapDelete(self)
             }).disposed(by: self.disposeBag)
     }
+    
+    private weak var _delegate: AddTodoDeleteJourneyTableViewCellDelegate?
     
     private let disposeBag = DisposeBag()
     

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoDropdownTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoDropdownTableViewCell.swift
@@ -16,8 +16,9 @@ protocol AddTodoDropdownTableViewCellDelegate: AddTodoTableViewCellDelegate {
 class AddTodoDropdownTableViewCell: AddTodoTableViewCell {
     override class var cellHeight: CGFloat { return UITableView.automaticDimension }
     
-    override weak var delegate: AddTodoTableViewCellDelegate? { didSet { self._delegate = self.delegate as? AddTodoDropdownTableViewCellDelegate } }
-    weak var _delegate: AddTodoDropdownTableViewCellDelegate?
+    override weak var delegate: AddTodoTableViewCellDelegate? {
+        didSet { self._delegate = self.delegate as? AddTodoDropdownTableViewCellDelegate }
+    }
     
     // MARK: - Life Cycle
     override func awakeFromNib() {
@@ -29,11 +30,30 @@ class AddTodoDropdownTableViewCell: AddTodoTableViewCell {
         self.bindTableView()
     }
     
-    override func configure(by addOptions: AddTodoVC.AddOptions, date: Date? = nil) {
+    override func configure(by addMode: AddTodoVC.AddMode, date: Date? = nil) {
+        super.configure(by: addMode, date: date)
+        
         self.viewModel.requestJourneyList(date)
+        
+        switch addMode {
+        case .editTodo(let todo):
+            let defaultJourney = JourneyTitleModel(
+                idx: nil,
+                title: "default",
+                year: nil,
+                month: nil,
+                weekNo: nil,
+                userIdx: nil
+            )
+            let journey = todo.journey ?? defaultJourney
+            self.updateSelectedJourney(journey)
+            
+        default:
+            break
+        }
     }
     
-    func updateSelectedJourney(_ journey: JourneyTitleModel) {
+    private func updateSelectedJourney(_ journey: JourneyTitleModel) {
         self.viewModel.updateSelectedMenu(journey)
     }
     
@@ -118,6 +138,8 @@ class AddTodoDropdownTableViewCell: AddTodoTableViewCell {
     private static let screenRatio: CGFloat         = DeviceInfo.screenWidth / 375
     private static let menuCellHeight: CGFloat      = 56 * screenRatio
     private static let selectBorderColor: UIColor   = UIColor.mainSky
+    
+    private weak var _delegate: AddTodoDropdownTableViewCellDelegate?
     
     private var viewModel  = AddTodoDropdownViewModel()
     private var disposeBag = DisposeBag()

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoFixOnTopTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoFixOnTopTableViewCell.swift
@@ -13,6 +13,7 @@ protocol AddTodoFixOnTopTableViewCellDelegate: AddTodoTableViewCellDelegate {
 }
 
 class AddTodoFixOnTopTableViewCell: AddTodoTableViewCell {
+    
     override class var cellHeight: CGFloat {
         let verticalInset: CGFloat  = 10
         let labelHeight: CGFloat    = 17
@@ -21,8 +22,12 @@ class AddTodoFixOnTopTableViewCell: AddTodoTableViewCell {
         return (verticalInset * 2) + labelHeight + spacing + buttonHeight
     }
     
-    override weak var delegate: AddTodoTableViewCellDelegate? { didSet { self._delegate = self.delegate as? AddTodoFixOnTopTableViewCellDelegate; self._delegate?.addTodoFixOnTopTableViewCell(self, shouldFixed: false) } }
-    weak var _delegate: AddTodoFixOnTopTableViewCellDelegate?
+    override weak var delegate: AddTodoTableViewCellDelegate? {
+        didSet {
+            self._delegate = self.delegate as? AddTodoFixOnTopTableViewCellDelegate
+            self._delegate?.addTodoFixOnTopTableViewCell(self, shouldFixed: false)
+        }
+    }
     
     // MARK: - Life Cycle
     override func awakeFromNib() {
@@ -32,7 +37,19 @@ class AddTodoFixOnTopTableViewCell: AddTodoTableViewCell {
         self.bindUI()
     }
     
-    func updateFix(_ fix: Bool) {
+    override func configure(by addMode: AddTodoVC.AddMode, date: Date? = nil) {
+        super.configure(by: addMode, date: date)
+        
+        switch addMode {
+        case .editTodo(let todo):
+            self.updateFix(todo.isTop ?? false)
+            
+        default:
+            break
+        }
+    }
+    
+    private func updateFix(_ fix: Bool) {
         fix ? self.setFixSelected() : self.setNotFixSelected()
         self._delegate?.addTodoFixOnTopTableViewCell(self, shouldFixed: fix)
     }
@@ -104,6 +121,8 @@ class AddTodoFixOnTopTableViewCell: AddTodoTableViewCell {
     
     private static let selectedBorderColor: UIColor         = UIColor.mainSky
     private static let unselectedBorderColor: UIColor       = UIColor.inactiveText
+    
+    private weak var _delegate: AddTodoFixOnTopTableViewCellDelegate?
     
     private var disposeBag = DisposeBag()
     private var fixed      = BehaviorSubject<Bool>(value: false)

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoSelectStarTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoSelectStarTableViewCell.swift
@@ -31,7 +31,22 @@ class AddTodoSelectStarTableViewCell: AddTodoTableViewCell {
         self.bindCollectionView()
     }
     
-    func updateSelectJourney(_ journeys: Set<Journey>) {
+    override func configure(by addMode: AddTodoVC.AddMode, date: Date? = nil) {
+        super.configure(by: addMode, date: date)
+        
+        switch addMode {
+        case .editJourney(let journey):
+            var journeySet: Set<Journey> = []
+            if let firstJourney = journey.firstValueJourney   { journeySet.insert(firstJourney) }
+            if let secondJourney = journey.secondValueJourney { journeySet.insert(secondJourney) }
+            self.updateSelectJourney(journeySet)
+            
+        default:
+            break
+        }
+    }
+    
+    private func updateSelectJourney(_ journeys: Set<Journey>) {
         self._delegate?.addTodoSelectStarTableViewCell(self, didSelectedStars: journeys)
         
         journeys.forEach { journey in self.viewModel.selectJourney(journey) }

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoTextTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoTextTableViewCell.swift
@@ -14,6 +14,7 @@ protocol AddTodoTextTableViewCellDelegate: AddTodoTableViewCellDelegate {
 }
 
 class AddTodoTextTableViewCell: AddTodoTableViewCell {
+    
     class override var cellHeight: CGFloat {
         let textFieldHeight: CGFloat = (screenRaito * 53)
         let space: CGFloat           = 15
@@ -21,8 +22,11 @@ class AddTodoTextTableViewCell: AddTodoTableViewCell {
         return (verticalInset * 2) + space + textFieldHeight + labelHeight
     }
     
-    override weak var delegate: AddTodoTableViewCellDelegate? { didSet { _delegate = self.delegate as? AddTodoTextTableViewCellDelegate } }
-    weak var _delegate: AddTodoTextTableViewCellDelegate?
+    override weak var delegate: AddTodoTableViewCellDelegate? {
+        didSet { _delegate = self.delegate as? AddTodoTextTableViewCellDelegate }
+    }
+    
+    private weak var _delegate: AddTodoTextTableViewCellDelegate?
     
     // MARK: - Life Cycle
     override func awakeFromNib() {
@@ -30,19 +34,31 @@ class AddTodoTextTableViewCell: AddTodoTableViewCell {
         self.setupTextFieldView()
     }
     
-    override func configure(by addOptions: AddTodoVC.AddOptions, date: Date?) {
+    override func configure(by addMode: AddTodoVC.AddMode, date: Date?) {
+        super.configure(by: addMode, date: date)
+        
         var addTodoCategory: AddTextCategory
-        if addOptions.contains(.perDayAddTodo) || addOptions.contains(.perJourneyAddTodo) {
-            addTodoCategory = AddTextCategory.todo
-        } else {
-            addTodoCategory = AddTextCategory.journey
+        switch addMode {
+        case .addJourneyTodo, .addDayTodo:
+            addTodoCategory = .todo
+            
+        case .editTodo(let todo):
+            addTodoCategory = .todo
+            self.updateAddText(todo.title ?? "")
+            
+        case .editJourney(let journey):
+            addTodoCategory = .journey
+            self.updateAddText(journey.title ?? "")
+            
+        default:
+            addTodoCategory = .journey
         }
         
         self.titleLabel.text = addTodoCategory.title
         self.polarisMarginTextFieldView?.setPlaceholder(text: addTodoCategory.placeHolder)
     }
     
-    func updateAddText(_ addText: String) {
+    private func updateAddText(_ addText: String) {
         self.polarisMarginTextFieldView?.setText(addText)
         self._delegate?.addTodoTextTableViewCell(self, didChangeText: addText)
     }
@@ -64,6 +80,7 @@ class AddTodoTextTableViewCell: AddTodoTableViewCell {
 }
 
 extension AddTodoTextTableViewCell {
+    
     enum AddTextCategory {
         case todo
         case journey
@@ -82,6 +99,7 @@ extension AddTodoTextTableViewCell {
             }
         }
     }
+    
 }
 
 extension AddTodoTextTableViewCell: PolarisMarginTextFieldDelegate {

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/MainSceneTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/MainSceneTableViewCell.swift
@@ -370,15 +370,13 @@ final class MainSceneTableViewCell: MainTableViewCell {
     }
     
     private func presentAddJourneyViewController() {
-        let viewController = AddTodoVC.instantiateFromStoryboard(StoryboardName.addTodo)
-        let currentDate = self.viewModel.currentDate
+        let param = AddTodoViewMakingParameter(
+            mode: .addJourney(self.viewModel.currentDate),
+            delegate: self
+        )
         
-        guard let visibleController = UIViewController.getVisibleController() else { return }
-        guard let addTodoVC = viewController                                  else { return }
-        
-        addTodoVC.setAddOptions(.addJourney)
-        addTodoVC.setAddJourneyDate(currentDate)
-        addTodoVC.delegate = self
+        guard let addTodoVC = AddTodoViewFactory.makeAddTodoViewController(param: param) else { return }
+        guard let visibleController = UIViewController.getVisibleController()            else { return }
         addTodoVC.presentWithAnimation(from: visibleController)
     }
     
@@ -505,7 +503,7 @@ extension MainSceneTableViewCell: WeekPickerDelegate {
 
 extension MainSceneTableViewCell: AddTodoViewControllerDelegate {
     
-    func addTodoViewController(_ viewController: AddTodoVC, didCompleteAddOption option: AddTodoVC.AddOptions) {
+    func addTodoViewController(_ viewController: AddTodoVC, didCompleteAddMode mode: AddTodoVC.AddMode) {
         self.viewModel.reloadInfo()
         NotificationCenter.default.postUpdateTodo(fromScene: .main)
     }

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/MainSceneTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/MainSceneTableViewCell.swift
@@ -87,9 +87,7 @@ final class MainSceneTableViewCell: MainTableViewCell {
     }
     
     private func setUIs(){
-        for _ in 0...2{
-            self.cometAnimation()
-        }
+        self.contentView.addCometAnimation()
         self.reloadButton.setTitle("", for: .normal)
         self.weekContainView.backgroundColor = .white20
         self.weekContainView.setBorder(borderColor: .white60, borderWidth: 1.0)
@@ -273,43 +271,6 @@ final class MainSceneTableViewCell: MainTableViewCell {
                 }
             })
             .disposed(by: self.disposeBag)
-    }
-    
-    private func setCometLayout(comet: UIImageView,size: Int) {
-        let heightConst = CGFloat(Int.random(in: 0...400))
-        var width: CGFloat = 0.0
-        if size == 0 {
-            width = 70.0
-        }
-        else {
-            width = 120.0
-        }
-        self.addSubview(comet)
-        comet.translatesAutoresizingMaskIntoConstraints = false
-        comet.leftAnchor.constraint(equalTo: self.rightAnchor).isActive = true
-        comet.bottomAnchor.constraint(equalTo: self.topAnchor,constant: heightConst).isActive = true
-        comet.heightAnchor.constraint(equalToConstant: width).isActive = true
-        comet.widthAnchor.constraint(equalToConstant: width).isActive = true
-    }
-    
-    
-    private func cometAnimation(){
-        
-        let cometImgNames = [ImageName.imgShootingstar,ImageName.imgShootingstar2]
-        
-        // 0: small, 1 : big
-        let cometSize = Int.random(in: 0...1)
-        let comet = UIImageView(image: UIImage(named: cometImgNames[cometSize]))
-        
-        setCometLayout(comet: comet, size: cometSize)
-        let duration = Double(Int.random(in: 15...60))/10.0
-        
-        UIView.animate(withDuration: duration,delay:0.0, options:.curveEaseIn,animations: {
-            comet.transform = CGAffineTransform(translationX: -DeviceInfo.screenWidth-120, y: DeviceInfo.screenWidth+120.0)
-        }, completion: { finished in
-            comet.removeFromSuperview()
-            self.cometAnimation()
-        })
     }
     
     @objc private func showWeekPicker(){

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/MainSceneTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/MainSceneTableViewCell.swift
@@ -313,10 +313,10 @@ final class MainSceneTableViewCell: MainTableViewCell {
     }
     
     @objc private func showWeekPicker(){
-        guard let currentDate = self.viewModel.currentDate                                         else { return }
         guard let weekPickerVC = WeekPickerVC.instantiateFromStoryboard(StoryboardName.weekPicker) else { return }
         guard let visibleController = UIViewController.getVisibleController()                      else { return }
         
+        let currentDate = self.viewModel.currentDate
         weekPickerVC.weekDelegate = self
         weekPickerVC.setWeekInfo(
             year: currentDate.year,
@@ -347,13 +347,7 @@ final class MainSceneTableViewCell: MainTableViewCell {
     }
     
     @IBAction func addNewJourneyButton(_ sender: Any) {
-        let viewController = AddTodoVC.instantiateFromStoryboard(StoryboardName.addTodo)
-        
-        guard let visibleController = UIViewController.getVisibleController() else { return }
-        guard let addTodoVC = viewController                                  else { return }
-        addTodoVC.setAddOptions(.addJourney)
-        addTodoVC.delegate = self
-        addTodoVC.presentWithAnimation(from: visibleController)
+        self.presentAddJourneyViewController()
     }
     
     
@@ -373,6 +367,19 @@ final class MainSceneTableViewCell: MainTableViewCell {
         guard let sceneIdentifier = notification.object as? String      else { return }
         guard sceneIdentifier != MainSceneCellType.main.sceneIdentifier else { return }
         self.viewModel.reloadInfo()
+    }
+    
+    private func presentAddJourneyViewController() {
+        let viewController = AddTodoVC.instantiateFromStoryboard(StoryboardName.addTodo)
+        let currentDate = self.viewModel.currentDate
+        
+        guard let visibleController = UIViewController.getVisibleController() else { return }
+        guard let addTodoVC = viewController                                  else { return }
+        
+        addTodoVC.setAddOptions(.addJourney)
+        addTodoVC.setAddJourneyDate(currentDate)
+        addTodoVC.delegate = self
+        addTodoVC.presentWithAnimation(from: visibleController)
     }
     
     private var dimView: UIView = UIView(frame: .zero)
@@ -480,15 +487,7 @@ extension MainSceneTableViewCell: LookBackCloseDelegate {
             lookbackViewController.viewModel.dateInfo = self.viewModel.lastWeekRelay.value
             visibleController.navigationController?.pushViewController(lookbackViewController, animated: true)
         } else {
-            let viewController = AddTodoVC.instantiateFromStoryboard(StoryboardName.addTodo)
-            
-            guard let currentDate = self.viewModel.currentDate                    else { return }
-            guard let visibleController = UIViewController.getVisibleController() else { return }
-            guard let addTodoVC = viewController                                  else { return }
-            addTodoVC.setAddOptions(.addJourney)
-            addTodoVC.setAddJourneyDate(currentDate)
-            addTodoVC.delegate = self
-            addTodoVC.presentWithAnimation(from: visibleController)
+            self.presentAddJourneyViewController()
         }
     }
     

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectTableViewCell.swift
@@ -11,12 +11,16 @@ import UIKit
 
 class RetrospectTableViewCell: MainTableViewCell {
     
-    override class var cellHeight: CGFloat { return DeviceInfo.screenHeight }
+    override class var cellHeight: CGFloat {
+        DeviceInfo.screenHeight
+    }
 
     override func awakeFromNib() {
         super.awakeFromNib()
         self.navigationHeightConstraint.constant = type(of: self).navigationHeight
-        self.setupCometAnimation()
+        self.addObserver()
+        self.addCometAnimation()
+//        self.setupCometAnimation()
         self.bindButtons()
         self.observeViewModel()
         
@@ -24,26 +28,14 @@ class RetrospectTableViewCell: MainTableViewCell {
         self.viewModel.requestLastWeekRetrospect()
     }
     
-    private func setupCometAnimation() {
-        (0...2).forEach { _ in self.startCometAnimation() }
+    private func addObserver() {
+        let center = NotificationCenter.default
+        center.addObserver(self, selector: #selector(self.didUpdateTodo(_:)), name: .didUpdateTodo, object: nil)
     }
     
-    private func startCometAnimation() {
-        guard let cometType = ShootingComet.allCases.randomElement() else { return }
-        
-        let yPosition = CGFloat(Int.random(in: 0...400))
-        let duration  = Double(Int.random(in: 15...60)) / 10.0
-        
-        let cometImageView   = UIImageView(image: cometType.starImage)
-        cometImageView.frame = CGRect(x: DeviceInfo.screenWidth, y: yPosition, width: cometType.size, height: cometType.size)
-        self.contentView.addSubview(cometImageView)
-
-        UIView.animate(withDuration: duration, delay: 0, options: .curveEaseIn, animations: {
-            cometImageView.transform = CGAffineTransform(translationX: -DeviceInfo.screenWidth - 120, y: DeviceInfo.screenWidth + 120)
-        }, completion: { [weak self] _ in
-            cometImageView.removeFromSuperview()
-            self?.startCometAnimation()
-        })
+    @objc private func didUpdateTodo(_ notification: Notification) {
+        guard let sceneIdentifier = notification.object as? String else { return }
+        print(notification)
     }
     
     private func bindButtons() {

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/RetrospectTableViewCell.swift
@@ -20,12 +20,10 @@ class RetrospectTableViewCell: MainTableViewCell {
         self.navigationHeightConstraint.constant = type(of: self).navigationHeight
         self.addObserver()
         self.addCometAnimation()
-//        self.setupCometAnimation()
         self.bindButtons()
         self.observeViewModel()
         
-        self.viewModel.requestRetrospectValues()
-        self.viewModel.requestLastWeekRetrospect()
+        self.viewModel.occur(viewEvent: .viewDidLoad)
     }
     
     private func addObserver() {
@@ -35,7 +33,7 @@ class RetrospectTableViewCell: MainTableViewCell {
     
     @objc private func didUpdateTodo(_ notification: Notification) {
         guard let sceneIdentifier = notification.object as? String else { return }
-        print(notification)
+        self.viewModel.occur(viewEvent: .notifyUpdateTodo(scene: sceneIdentifier))
     }
     
     private func bindButtons() {

--- a/polaris-ios/polaris-ios/Sources/TodoList/View/TodoTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/TodoList/View/TodoTableViewCell.swift
@@ -79,15 +79,19 @@ class TodoTableViewCell: MainTableViewCell {
             self.viewModel.occur(viewEvent: .categoryBtnTapped)
         }).disposed(by: self.disposeBag)
         
-        self.addJourneyButton.rx.tap.observeOnMain(onNext: { [weak self] in            
-            let viewController = AddTodoVC.instantiateFromStoryboard(StoryboardName.addTodo)
-            
-            guard let visibleController = UIViewController.getVisibleController() else { return }
-            guard let addTodoVC = viewController                                  else { return }
-            addTodoVC.setAddOptions(.addJourney)
-            addTodoVC.delegate = self?.viewModel
-            addTodoVC.presentWithAnimation(from: visibleController)
-        }).disposed(by: self.disposeBag)
+        self.addJourneyButton.rx.tap
+            .withUnretained(self)
+            .observeOnMain(onNext: { owner, _ in
+                let param = AddTodoViewMakingParameter(
+                    mode: .addJourney(owner.viewModel.currentDate),
+                    delegate: owner.viewModel
+                )
+                
+                guard let addTodoVC = AddTodoViewFactory.makeAddTodoViewController(param: param) else { return }
+                guard let visibleController = UIViewController.getVisibleController()            else { return }
+                addTodoVC.presentWithAnimation(from: visibleController)
+            })
+            .disposed(by: self.disposeBag)
     }
     
     private func observeViewModel() {
@@ -277,11 +281,13 @@ extension TodoTableViewCell: UITableViewDelegate {
 extension TodoTableViewCell: DayTodoHeaderViewDelegate {
     
     func dayTodoHeaderView(_ dayTodoHeaderView: DayTodoHeaderView, didTapAddTodo date: Date) {
-        guard let addTodoVC = AddTodoVC.instantiateFromStoryboard(StoryboardName.addTodo),
-              let visibleController = UIViewController.getVisibleController() else { return }
-        addTodoVC.setAddOptions(.perDayAddTodo)
-        addTodoVC.setAddTodoDate(date)
-        addTodoVC.delegate = self.viewModel
+        let param = AddTodoViewMakingParameter(
+            mode: .addDayTodo(date),
+            delegate: self.viewModel
+        )
+        
+        guard let addTodoVC = AddTodoViewFactory.makeAddTodoViewController(param: param) else { return }
+        guard let visibleController = UIViewController.getVisibleController()            else { return }
         addTodoVC.presentWithAnimation(from: visibleController)
     }
     
@@ -290,20 +296,24 @@ extension TodoTableViewCell: DayTodoHeaderViewDelegate {
 extension TodoTableViewCell: JourneyTodoHeaderViewDelegate {
     
     func journeyTodoHeaderView(_ journeyTodoHeaderView: JourneyTodoHeaderView, didTapEdit todo: WeekJourneyModel) {
-        guard let addTodoVC = AddTodoVC.instantiateFromStoryboard(StoryboardName.addTodo),
-              let visibleController = UIViewController.getVisibleController() else { return }
-        addTodoVC.setJourneyModel(todo)
-        addTodoVC.setAddOptions(.edittedJourney)
-        addTodoVC.delegate = self.viewModel
+        let param = AddTodoViewMakingParameter(
+            mode: .editJourney(todo),
+            delegate: self.viewModel
+        )
+        
+        guard let addTodoVC = AddTodoViewFactory.makeAddTodoViewController(param: param) else { return }
+        guard let visibleController = UIViewController.getVisibleController()            else { return }
         addTodoVC.presentWithAnimation(from: visibleController)
     }
     
     func journeyTodoHeaderView(_ journeyTodoHeaderView: JourneyTodoHeaderView, didTapAdd todo: WeekJourneyModel) {
-        guard let addTodoVC = AddTodoVC.instantiateFromStoryboard(StoryboardName.addTodo),
-              let visibleController = UIViewController.getVisibleController() else { return }
-        addTodoVC.setAddOptions(.perJourneyAddTodo)
-        addTodoVC.setJourneyModel(todo)
-        addTodoVC.delegate = self.viewModel
+        let param = AddTodoViewMakingParameter(
+            mode: .addJourneyTodo(todo),
+            delegate: self.viewModel
+        )
+        
+        guard let addTodoVC = AddTodoViewFactory.makeAddTodoViewController(param: param) else { return }
+        guard let visibleController = UIViewController.getVisibleController()            else { return }
         addTodoVC.presentWithAnimation(from: visibleController)
     }
     
@@ -331,12 +341,13 @@ extension TodoTableViewCell: DayTodoTableViewCellDelegate {
     }
     
     func dayTodoTableViewCell(_ cell: DayTodoTableViewCell, didTapEdit todo: TodoModel) {
-        guard let addTodoVC = AddTodoVC.instantiateFromStoryboard(StoryboardName.addTodo),
-              let visibleController = UIViewController.getVisibleController() else { return }
+        let param = AddTodoViewMakingParameter(
+            mode: .editTodo(todo),
+            delegate: self.viewModel
+        )
         
-        addTodoVC.setAddOptions(.edittedTodo)
-        addTodoVC.setEditTodo(todo)
-        addTodoVC.delegate = self.viewModel
+        guard let addTodoVC = AddTodoViewFactory.makeAddTodoViewController(param: param) else { return }
+        guard let visibleController = UIViewController.getVisibleController()            else { return }
         addTodoVC.presentWithAnimation(from: visibleController)
     }
     
@@ -353,12 +364,13 @@ extension TodoTableViewCell: JourneyTodoTableViewDelegate {
     }
     
     func journeyTodoTableViewCell(_ cell: JourneyTodoTableViewCell, didTapEdit todo: TodoModel) {
-        guard let addTodoVC = AddTodoVC.instantiateFromStoryboard(StoryboardName.addTodo),
-              let visibleController = UIViewController.getVisibleController() else { return }
+        let param = AddTodoViewMakingParameter(
+            mode: .editTodo(todo),
+            delegate: self.viewModel
+        )
         
-        addTodoVC.setAddOptions(.edittedTodo)
-        addTodoVC.setEditTodo(todo)
-        addTodoVC.delegate = self.viewModel
+        guard let addTodoVC = AddTodoViewFactory.makeAddTodoViewController(param: param) else { return }
+        guard let visibleController = UIViewController.getVisibleController()            else { return }
         addTodoVC.presentWithAnimation(from: visibleController)
     }
     

--- a/polaris-ios/polaris-ios/Sources/TodoList/ViewModel/TodoViewModel.swift
+++ b/polaris-ios/polaris-ios/Sources/TodoList/ViewModel/TodoViewModel.swift
@@ -239,7 +239,7 @@ final class TodoViewModel {
 
 extension TodoViewModel: AddTodoViewControllerDelegate {
     
-    func addTodoViewController(_ viewController: AddTodoVC, didCompleteAddOption option: AddTodoVC.AddOptions) {
+    func addTodoViewController(_ viewController: AddTodoVC, didCompleteAddMode mode: AddTodoVC.AddMode) {
         self.reloadTodoList(ofDate: self.currentDate, shouldScroll: false)
         NotificationCenter.default.postUpdateTodo(fromScene: .todoList)
     }

--- a/polaris-ios/polaris-ios/Sources/ViewController/AddTodoVC+Delegate.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/AddTodoVC+Delegate.swift
@@ -42,10 +42,15 @@ extension AddTodoVC: AddTodoSelectStarTableViewCellDelegate {
 extension AddTodoVC: AddTodoDeleteJourneyTableViewCellDelegate {
     func addTodoDeleteJourneyTableViewCellDidTapDelete(_ cell: AddTodoDeleteJourneyTableViewCell) {
         guard let popupView: PolarisPopupView = UIView.fromNib() else { return }
-        popupView.configure(title: "이 여정을 삭제할까요?", subTitle: "한 번 삭제한 여정은 복구되지 않아요.", confirmTitle: "삭제하기",
-                            confirmHandler: { [weak self] in
-                                self?.viewModel.requestDeleteJourney()
-                            }, cancelHandler: nil)
+        popupView.configure(
+            title: "이 여정을 삭제할까요?",
+            subTitle: "한 번 삭제한 여정은 복구되지 않아요.",
+            confirmTitle: "삭제하기",
+            confirmHandler: { [weak self] in
+                self?.viewModel.occur(viewEvent: .didTapDeleteJourney)
+            },
+            cancelHandler: nil
+        )
         popupView.show(in: self.view)
     }
 }

--- a/polaris-ios/polaris-ios/Sources/ViewController/Intro/LoginVC.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewController/Intro/LoginVC.swift
@@ -91,25 +91,7 @@ final class LoginVC: UIViewController {
     }
     
     private func setupCometAnimation() {
-        (0...2).forEach { _ in self.startCometAnimation() }
-    }
-    
-    private func startCometAnimation() {
-        guard let cometType = ShootingComet.allCases.randomElement() else { return }
-        
-        let yPosition = CGFloat(Int.random(in: 0...400))
-        let duration  = Double(Int.random(in: 15...60)) / 10.0
-        
-        let cometImageView   = UIImageView(image: cometType.starImage)
-        cometImageView.frame = CGRect(x: DeviceInfo.screenWidth, y: yPosition, width: cometType.size, height: cometType.size)
-        self.view.addSubview(cometImageView)
-
-        UIView.animate(withDuration: duration, delay: 0, options: .curveEaseIn, animations: {
-            cometImageView.transform = CGAffineTransform(translationX: -DeviceInfo.screenWidth - 120, y: DeviceInfo.screenWidth + 120)
-        }, completion: { [weak self] _ in
-            cometImageView.removeFromSuperview()
-            self?.startCometAnimation()
-        })
+        self.view.addCometAnimation()
     }
     
     private func startLoadingIndicator() {

--- a/polaris-ios/polaris-ios/Sources/ViewModel/AddTodo/AddTodoViewModel.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewModel/AddTodo/AddTodoViewModel.swift
@@ -29,21 +29,17 @@ class AddTodoViewModel {
         self.addModeRelay.value
     }
     
-    var addOptionCount: Int {
-        return (try? self.addListTypes.value().count) ?? 0
-    }
+    let addListTypes = BehaviorSubject<[AddTodoTableViewCellProtocol.Type]>(value: [])
     
-    let addListTypes    = BehaviorSubject<[AddTodoTableViewCellProtocol.Type]>(value: [])
-    
-    let addTextRelay       = BehaviorRelay<String?>(value: nil)
-    let dropdownRelay      = BehaviorRelay<JourneyTitleModel?>(value: nil)
-    let fixOnTopRelay      = BehaviorRelay<Bool?>(value: nil)
-    let selectDateRelay    = BehaviorRelay<Date?>(value: nil)
+    let addTextRelay = BehaviorRelay<String?>(value: nil)
+    let dropdownRelay = BehaviorRelay<JourneyTitleModel?>(value: nil)
+    let fixOnTopRelay = BehaviorRelay<Bool?>(value: nil)
+    let selectDateRelay = BehaviorRelay<Date?>(value: nil)
     let selectJourneyRelay = BehaviorRelay<Set<Journey>?>(value: nil)
     
-    let addEnableFlagSubject   = BehaviorSubject<Bool>(value: false)
+    let addEnableFlagSubject = BehaviorSubject<Bool>(value: false)
     let completeRequestSubject = PublishSubject<Void>()
-    let loadingSubject         = BehaviorSubject<Bool>(value: false)
+    let loadingSubject = BehaviorSubject<Bool>(value: false)
     
     init() {
         self.observeMode(self.addModeRelay)

--- a/polaris-ios/polaris-ios/Sources/ViewModel/AddTodo/AddTodoViewModel.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewModel/AddTodo/AddTodoViewModel.swift
@@ -12,13 +12,21 @@ import RxRelay
 class AddTodoViewModel {
     
     var currentDate: Date? {
-        if self.currentAddOption == .perDayAddTodo {
-            return self.addTodoDate
-        } else if self.currentAddOption == .edittedTodo {
-            return self.todoModel?.date?.convertToDate()?.normalizedDate
-        } else {
+        guard let addMode = self.addMode else { return nil }
+        switch addMode {
+        case .addDayTodo(let date):
+            return date
+            
+        case .editTodo(let todo):
+            return todo.date?.convertToDate()?.normalizedDate
+            
+        default:
             return nil
         }
+    }
+    
+    var addMode: AddTodoVC.AddMode? {
+        self.addModeRelay.value
     }
     
     var addOptionCount: Int {
@@ -37,157 +45,210 @@ class AddTodoViewModel {
     let completeRequestSubject = PublishSubject<Void>()
     let loadingSubject         = BehaviorSubject<Bool>(value: false)
     
-    func setViewModel(by addOptions: AddTodoVC.AddOptions) {
-        self.currentAddOption = addOptions
-        self.addListTypes.onNext(addOptions.addCellTypes)
-        self.bindEnableFlag(by: addOptions)
+    init() {
+        self.observeMode(self.addModeRelay)
+        self.observeViewEvent(self.viewEventRelay)
     }
     
-    func setAddTodoDate(_ date: Date) {
-        self.addTodoDate = date
+    func setAddMode(_ mode: AddTodoVC.AddMode) {
+        self.addModeRelay.accept(mode)
     }
     
-    func setEditTodoModel(_ todo: TodoModel) {
-        self.todoModel = todo
+    func occur(viewEvent: ViewEvent) {
+        self.viewEventRelay.accept(viewEvent)
     }
     
-    func setJourneyModel(_ journeyModel: WeekJourneyModel) {
-        self.journeyModel = journeyModel
-    }
-    
-    func setAddJourneyDate(_ date: PolarisDate) {
-        self.addJourneyDate = date
-    }
-    
-    func requestAddTodo() {
-        self.loadingSubject.onNext(true)
-        if self.currentAddOption == .perDayAddTodo {
-            self.requestAddTodoDay()
-        } else if self.currentAddOption == .perJourneyAddTodo {
-            self.requestAddTodoJourney()
-        } else if self.currentAddOption == .addJourney {
-            self.requestAddJourney()
-        } else if self.currentAddOption == .edittedTodo {
-            self.requestEditTodo()
-        } else if self.currentAddOption == .edittedJourney {
-            self.requestEditJourney()
-        }
-    }
-    
-    func requestDeleteJourney() {
-        guard let journey = self.journeyModel else { return }
-        guard let idx = journey.idx           else { return }
-        
-        self.loadingSubject.onNext(true)
-        let deleteJourneyAPI = JourneyAPI.deleteJourney(idx: idx)
-        NetworkManager.request(apiType: deleteJourneyAPI).subscribe(onSuccess: { [weak self] (successModel: SuccessModel) in
-            guard let self = self else { return }
-            self.loadingSubject.onNext(false)
-            
-            guard successModel.isSuccess == true else { return }
-            self.completeRequestSubject.onNext(())
-        }, onFailure: { [weak self] _ in
-            self?.loadingSubject.onNext(false)
-        }).disposed(by: self.disposeBag)
-    }
-    
-    private func requestAddTodoDay() {
-        guard let addText = self.addTextRelay.value   else { return }
-        guard let fixOnTop = self.fixOnTopRelay.value else { return }
-        guard let addTodoDate = self.currentDate      else { return }
-        
-        let journey = self.dropdownRelay.value
-        
-        let createTodoAPI = TodoAPI.createToDo(title: addText, date: addTodoDate.convertToString(),
-                                               journeyIdx: journey?.idx, isTop: fixOnTop)
-        NetworkManager.request(apiType: createTodoAPI).subscribe(onSuccess: { [weak self] (responseModel: AddTodoResponseModel) in
-            self?.completeRequestSubject.onNext(())
-            self?.loadingSubject.onNext(false)
-        }, onFailure: { [weak self] error in
-            self?.loadingSubject.onNext(false)
-        }).disposed(by: self.disposeBag)
-    }
-    
-    private func requestAddTodoJourney() {
-        guard let addText = self.addTextRelay.value        else { return }
-        guard let addTodoDate = self.selectDateRelay.value else { return }
-        guard let fixOnTop = self.fixOnTopRelay.value      else { return }
-        guard let journey = self.journeyModel            else { return }
-
-        let createTodoAPI = TodoAPI.createToDo(title: addText, date: addTodoDate.convertToString(),
-                                               journeyIdx: journey.idx, isTop: fixOnTop)
-        NetworkManager.request(apiType: createTodoAPI).subscribe(onSuccess: { [weak self] (responseModel: AddTodoResponseModel) in
-            self?.completeRequestSubject.onNext(())
-            self?.loadingSubject.onNext(false)
-        }, onFailure: { [weak self] error in
-            self?.loadingSubject.onNext(false)
-        }).disposed(by: self.disposeBag)
-    }
-    
-    private func requestAddJourney() {
-        guard let addText = self.addTextRelay.value          else { return }
-        guard var journeySet = self.selectJourneyRelay.value else { return }
-        
-        let firstJourney: Journey   = journeySet.removeFirst()
-        let secondJourney: Journey? = journeySet.isEmpty == false ? journeySet.removeFirst() : nil
-        
-        self.journeyDateObservable
-            .flatMapLatest { journeyDate -> Observable<WeekJourneyModel> in
-                let createJourney = JourneyAPI.createJourney(
-                    title: addText,
-                    value1: firstJourney.rawValue,
-                    value2: secondJourney?.rawValue,
-                    date: journeyDate
-                )
-                return NetworkManager.request(apiType: createJourney).asObservable()
-            }
-            .subscribe(onNext: { [weak self] journeyModel in
-                self?.completeRequestSubject.onNext(())
-                self?.loadingSubject.onNext(false)
-            }, onError: { [weak self] error in
-                self?.loadingSubject.onNext(false)
+    private func observeMode(_ modeRelay: BehaviorRelay<AddTodoVC.AddMode?>) {
+        modeRelay
+            .compactMap { $0 }
+            .withUnretained(self)
+            .subscribe(onNext: { owner, mode in
+                owner.bindEnableFlag(by: mode.addOptions)
+                owner.addListTypes.onNext(mode.addOptions.addCellTypes)
             })
             .disposed(by: self.disposeBag)
     }
     
-    private func requestEditTodo() {
-        guard let todoModel = self.todoModel else { return }
-        guard let idx = todoModel.idx        else { return }
-        
-        guard let edittedText = self.addTextRelay.value      else { return }
-        guard let edittedDate = self.selectDateRelay.value   else { return }
-        guard let edittedJourney = self.dropdownRelay.value  else { return }
-        guard let edittedFixOnTop = self.fixOnTopRelay.value else { return }
-        
-        let todoEditAPI = TodoAPI.editTodo(idx: idx, title: edittedText, date: edittedDate.convertToString(),
-                                           journeyIdx: edittedJourney.idx, isTop: edittedFixOnTop)
-        NetworkManager.request(apiType: todoEditAPI).subscribe(onSuccess: { [weak self] (responseModel: TodoModel)  in
-            self?.completeRequestSubject.onNext(())
-            self?.loadingSubject.onNext(false)
-        }, onFailure: { [weak self] _ in
-            self?.loadingSubject.onNext(false)
-        }).disposed(by: self.disposeBag)
+    private func observeViewEvent(_ viewEventRelay: PublishRelay<ViewEvent>) {
+        viewEventRelay
+            .withUnretained(self)
+            .subscribe(onNext: { owner, viewEvent in
+                owner.handleViewEvent(viewEvent)
+            })
+            .disposed(by: self.disposeBag)
     }
     
-    private func requestEditJourney() {
-        guard let journeyModel = self.journeyModel else { return }
-        guard let idx = journeyModel.idx           else { return }
+    private func handleViewEvent(_ event: ViewEvent) {
+        switch event {
+        case .didTapAddButton:
+            guard let mode = self.addModeRelay.value else { return }
+            self.executeAddAction(asMode: mode)
+            
+        case .didTapDeleteJourney:
+            self.executeDeleteAction()
+        }
+    }
+    
+    private func executeAddAction(asMode mode: AddTodoVC.AddMode) {
+        var successObservable: Observable<Bool>
+        switch mode {
+        case .addDayTodo(let date):
+            successObservable = self.addDayTodoObservable(ofDate: date)
+            
+        case .addJourneyTodo(let journey):
+            successObservable = self.addJourneyTodoObservable(ofJourney: journey)
+            
+        case .addJourney(let polarisDate):
+            successObservable = self.addJourneyObservable(ofPolarisDate: polarisDate)
+            
+        case .editTodo(let todo):
+            successObservable = self.editTodoObservable(ofTodo: todo)
+            
+        case .editJourney(let journey):
+            successObservable = self.editJourneyObservable(ofJourney: journey)
+        }
         
-        guard let edittedText = self.addTextRelay.value      else { return }
-        guard var journeySet = self.selectJourneyRelay.value else { return }
+        self.loadingSubject.onNext(true)
+        successObservable
+            .withUnretained(self)
+            .do(
+                onNext: { owner, _ in owner.loadingSubject.onNext(false) },
+                onError: { [weak self] _ in self?.loadingSubject.onNext(false) }
+            )
+            .subscribe(onNext: { owner, isSuccess in
+                guard isSuccess == true else { return }
+                owner.completeRequestSubject.onNext(())
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
+    private func executeDeleteAction() {
+        self.deleteJourneyObservable()
+            .withUnretained(self)
+            .do(
+                onNext: { owner, _ in owner.loadingSubject.onNext(false) },
+                onError: { [weak self] _ in self?.loadingSubject.onNext(false) }
+            )
+            .subscribe(onNext: { owner, isSuccess in
+                guard isSuccess == true else { return }
+                owner.completeRequestSubject.onNext(())
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
+    private func addDayTodoObservable(ofDate date: Date) -> Observable<Bool> {
+        guard let addText = self.addTextRelay.value   else { return .just(false) }
+        guard let fixOnTop = self.fixOnTopRelay.value else { return .just(false) }
+        
+        let journey = self.dropdownRelay.value
+        let createTodoAPI = TodoAPI.createToDo(
+            title: addText,
+            date: date.convertToString(),
+            journeyIdx: journey?.idx,
+            isTop: fixOnTop
+        )
+        
+        return NetworkManager.request(apiType: createTodoAPI)
+            .asObservable()
+            .map { (responseModel: AddTodoResponseModel) in
+                return true
+            }
+    }
+    
+    private func addJourneyTodoObservable(ofJourney journey: WeekJourneyModel) -> Observable<Bool> {
+        guard let addText = self.addTextRelay.value        else { return .just(false) }
+        guard let addTodoDate = self.selectDateRelay.value else { return .just(false) }
+        guard let fixOnTop = self.fixOnTopRelay.value      else { return .just(false) }
+        
+        let createTodoAPI = TodoAPI.createToDo(
+            title: addText,
+            date: addTodoDate.convertToString(),
+            journeyIdx: journey.idx,
+            isTop: fixOnTop
+        )
+        
+        return NetworkManager.request(apiType: createTodoAPI)
+            .asObservable()
+            .map { (responseModel: AddTodoResponseModel) in
+                return true
+            }
+    }
+    
+    private func addJourneyObservable(ofPolarisDate date: PolarisDate) -> Observable<Bool> {
+        guard let addText = self.addTextRelay.value          else { return .just(false) }
+        guard var journeySet = self.selectJourneyRelay.value else { return .just(false) }
+        
+        let firstJourney: Journey   = journeySet.removeFirst()
+        let secondJourney: Journey? = journeySet.isEmpty == false ? journeySet.removeFirst() : nil
+        
+        let createJourneyAPI = JourneyAPI.createJourney(
+            title: addText,
+            value1: firstJourney.rawValue,
+            value2: secondJourney?.rawValue,
+            date: date
+        )
+        
+        return NetworkManager.request(apiType: createJourneyAPI)
+            .asObservable()
+            .map { (journeyModel: WeekJourneyModel) in
+                return true
+            }
+    }
+    
+    private func editTodoObservable(ofTodo todo: TodoModel) -> Observable<Bool> {
+        guard let idx = todo.idx                             else { return .just(false) }
+        guard let edittedText = self.addTextRelay.value      else { return .just(false) }
+        guard let edittedDate = self.selectDateRelay.value   else { return .just(false) }
+        guard let edittedJourney = self.dropdownRelay.value  else { return .just(false) }
+        guard let edittedFixOnTop = self.fixOnTopRelay.value else { return .just(false) }
+        
+        let todoEditAPI = TodoAPI.editTodo(
+            idx: idx,
+            title: edittedText,
+            date: edittedDate.convertToString(),
+            journeyIdx: edittedJourney.idx,
+            isTop: edittedFixOnTop
+        )
+        return NetworkManager.request(apiType: todoEditAPI)
+            .asObservable()
+            .map { (responseModel: TodoModel) in
+                return true
+            }
+    }
+    
+    private func editJourneyObservable(ofJourney journey: WeekJourneyModel) -> Observable<Bool> {
+        guard let idx = journey.idx                          else { return .just(false) }
+        guard let edittedText = self.addTextRelay.value      else { return .just(false) }
+        guard var journeySet = self.selectJourneyRelay.value else { return .just(false) }
         
         let firstJourney  = journeySet.removeFirst().rawValue
         let secondJourney = journeySet.isEmpty == false ? journeySet.removeFirst().rawValue : nil
         
-        let journeyEditAPI = JourneyAPI.edittedJourney(idx: idx, title: edittedText,
-                                                       value1: firstJourney, value: secondJourney)
-        NetworkManager.request(apiType: journeyEditAPI).subscribe(onSuccess: { [weak self] (journey: WeekJourneyModel) in
-            guard let self = self else { return }
-            self.loadingSubject.onNext(false)
-            self.completeRequestSubject.onNext(())
-        }, onFailure: { [weak self] _ in
-            self?.loadingSubject.onNext(false)
-        }).disposed(by: self.disposeBag)
+        let journeyEditAPI = JourneyAPI.edittedJourney(
+            idx: idx,
+            title: edittedText,
+            value1: firstJourney,
+            value: secondJourney
+        )
+        return NetworkManager.request(apiType: journeyEditAPI)
+            .asObservable()
+            .map { (journey: WeekJourneyModel) in
+                return true
+            }
+    }
+    
+    private func deleteJourneyObservable() -> Observable<Bool> {
+        guard let addMode = self.addMode                  else { return .just(false) }
+        guard addMode.addOptions.contains(.deleteJourney) else { return .just(false) }
+        
+        guard let journeyIDx = self.journey?.idx else { return .just(false) }
+            
+        let deleteJourneyAPI = JourneyAPI.deleteJourney(idx: journeyIDx)
+        return NetworkManager.request(apiType: deleteJourneyAPI)
+            .asObservable()
+            .map { (successModel: SuccessModel) in
+                return successModel.isSuccess == true
+            }
     }
     
     private func bindEnableFlag(by addOptions: AddTodoVC.AddOptions) {
@@ -246,29 +307,31 @@ class AddTodoViewModel {
         }
     }
     
-    private var journeyDateObservable: Observable<PolarisDate> {
-        if let journeyDate = self.addJourneyDate {
-            return Observable.just(journeyDate)
-        } else {
-            let date = PolarisDate(year: Date.currentYear, month: Date.currentMonth, weekNo: Date.currentWeekOfMonth)
-            return Observable.just(date)
+    private var journey: WeekJourneyModel? {
+        switch self.addMode {
+        case .addJourneyTodo(let journey):
+            return journey
+            
+        case .editJourney(let journey):
+            return journey
+            
+        default:
+            return nil
         }
     }
     
     private let disposeBag = DisposeBag()
     
-    // 날짜에 더할때만 씀 - Day Todo
-    private(set) var addTodoDate: Date?
+    private let viewEventRelay = PublishRelay<ViewEvent>()
+    private let addModeRelay = BehaviorRelay<AddTodoVC.AddMode?>(value: nil)
     
-    // 여정별 할 일 더할 때만 씀 - Journey Todo
-    private(set) var journeyModel: WeekJourneyModel?
+}
+
+extension AddTodoViewModel {
     
-    // 일정 수정할 때 씀 - Edit Todo
-    private(set) var todoModel: TodoModel?
-    
-    // 여정 추가할 때 - PolarisDate
-    private(set) var addJourneyDate: PolarisDate?
-    
-    private(set) var currentAddOption: AddTodoVC.AddOptions?
+    enum ViewEvent {
+        case didTapAddButton
+        case didTapDeleteJourney
+    }
     
 }

--- a/polaris-ios/polaris-ios/Sources/ViewModel/MainSceneViewModel.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewModel/MainSceneViewModel.swift
@@ -23,7 +23,7 @@ class MainSceneViewModel {
     
     var reloadQueue = DispatchQueue(label: "MainSceneReloadQueue")
     
-    var currentDate: PolarisDate? {
+    var currentDate: PolarisDate {
         MainSceneDateSelector.shared.selectedDate
     }
     
@@ -236,7 +236,7 @@ class MainSceneViewModel {
     }
     
     func reloadInfo() {
-        guard let currentDate = self.currentDate else { return }
+        let currentDate = self.currentDate
         MainSceneDateSelector.shared.updateDate(currentDate)
     }
     
@@ -270,9 +270,9 @@ class MainSceneViewModel {
         let edittedIsDone = todoModel.isDone == nil ? true : false
         let todoEditAPI   = TodoAPI.editTodo(idx: todoIdx, isDone: edittedIsDone)
         
-        NetworkManager.request(apiType: todoEditAPI).subscribe(onSuccess: { (responseModel: TodoModel) in
-            guard let currentDate = self.currentDate else { return }
-
+        NetworkManager.request(apiType: todoEditAPI).subscribe(onSuccess: { [weak self] (responseModel: TodoModel) in
+            guard let currentDate = self?.currentDate else { return }
+            
             MainSceneDateSelector.shared.updateDate(currentDate)
             NotificationCenter.default.postUpdateTodo(fromScene: .main)
         }).disposed(by: self.disposeBag)


### PR DESCRIPTION
### PR 내용

#### Refactor
* AddTodoVC가 Options에 따라 받을 수 있는 파라메터 변수가 너무 늘어남
    * as-is
        * 현재는 옵션에 따라 다 다르게 받는 파라메터들이 Optional로 되어서 어떤 모드에서 사용하는 변수인지 알기 어려움
        
    * to-be
        * `enum AddMode`에 따라 받을 수 있는 변수를 설정
        * `AddOptions`는 Mode에 따라 뷰를 보여줄 수 있는 `OptionSet`으로 활용

* 배경에 별동별 애니메이션 `UIView+ Extension`으로 정리 [커밋 bfccb44](https://github.com/Polaris-Sopterm/Polaris-iOS/pull/60/commits/bfccb443639c8e126473c812bc0e037d6fbe8fbc)

* `AddTodoViewFactory` 생성

#### QA
* [[QA] 과거 주차 선택 후, 여정 추가 시 과거 주차로 여정이 추가 안됌](https://www.notion.so/aeb17fff51e54b039d368c22f99e4018)
    * `AddTodoVC` 보여줄 때, Date 넘겨줌

* [[QA] 여정별 할 일 완료 시, 회고 리포트 뷰에 밝아지는 별이 변하지 않음](https://www.notion.so/f58cb56089624abbba55707d35f66dfd)
    * 할 일 완료 시마다 새롭게 요청해서 UI Reload

### 관련 이슈
* #47 