### PR TITLE
[QA] 여정별 할일 리스트 버그 수정 

### DIFF
--- a/polaris-ios/PolarisBetaTests/DateTests.swift
+++ b/polaris-ios/PolarisBetaTests/DateTests.swift
@@ -11,37 +11,8 @@ import Foundation
 
 fileprivate extension Date {
     
-    static func normalizedDate(date: Date) -> Date {
-        Calendar.koreaISO8601.date(bySettingHour: 12, minute: 0, second: 0, of: date) ?? date
-    }
-    
-    static func datesIncludedInWeekFromDate(date: Date) -> [Date] {
-        let weekDay = Calendar.koreaISO8601.component(.weekday, from: normalizedDate(date: date))
-        var datesIncludedWeek: [Date]      = []
-        var distancesBetweenWeekDay: [Int] = []
-        
-        if weekDay == WeekDay.sunday.rawValue {
-            distancesBetweenWeekDay = [-6, -5, -4, -3, -2, -1, 0] }
-        else {
-            for weekDayValue in WeekDay.monday.rawValue...WeekDay.saturday.rawValue {
-                let tempDistanceBetweenWeekDay = weekDayValue - weekDay
-                distancesBetweenWeekDay.append(tempDistanceBetweenWeekDay)
-            }
-            
-            let sundayWeekDay = 8
-            distancesBetweenWeekDay.append(sundayWeekDay - weekDay)
-        }
-        
-        distancesBetweenWeekDay.forEach { distance in
-            guard let calculatedDate = Calendar.koreaISO8601.date(byAdding: .day, value: distance, to: normalizedDate(date: date)) else { return }
-            datesIncludedWeek.append(calculatedDate)
-        }
-        
-        return datesIncludedWeek
-    }
-    
     static func thursdayOfWeekIncludesDate(date: Date) -> Date {
-        return datesIncludedInWeekFromDate(date: normalizedDate(date: date))[3]
+        return datesIncludedInWeek(fromDate: date.normalizedDate ?? date)[3]
     }
     
     static func weekNoOfDate(date: Date) -> Int {

--- a/polaris-ios/polaris-ios/Resources/Extension/Date+.swift
+++ b/polaris-ios/polaris-ios/Resources/Extension/Date+.swift
@@ -128,6 +128,23 @@ extension Date {
         return datesIncludedWeek
     }
     
+    static func datesIncludedInWeek(fromPolarisDate date: PolarisDate) -> [Date] {
+        let dateComponents = DateComponents(
+            calendar: .koreaISO8601,
+            timeZone: .korea,
+            year: date.year,
+            month: date.month,
+            hour: 12,
+            minute: 0,
+            second: 0,
+            weekday: WeekDay.thursday.rawValue,
+            weekOfMonth: date.weekNo
+        )
+        
+        let dateFromComponent = Calendar.koreaISO8601.date(from: dateComponents) ?? .normalizedCurrent
+        return Self.datesIncludedInWeek(fromDate: dateFromComponent)
+    }
+    
     func convertToString(using format: String = "yyyy-MM-dd") -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")

--- a/polaris-ios/polaris-ios/Resources/Extension/Date+.swift
+++ b/polaris-ios/polaris-ios/Resources/Extension/Date+.swift
@@ -69,29 +69,7 @@ extension Date {
     /// - 토 index : 5
     /// - 일 index : 6
     static var datesIncludedThisWeek: [Date] {
-        let currentWeekDay = Calendar.koreaISO8601.component(.weekday, from: self.normalizedCurrent)
-        
-        var datesIncludedWeek: [Date]      = []
-        var distancesBetweenWeekDay: [Int] = []
-        
-        if currentWeekDay == WeekDay.sunday.rawValue {
-            distancesBetweenWeekDay = [-6, -5, -4, -3, -2, -1, 0] }
-        else {
-            for weekDay in WeekDay.monday.rawValue...WeekDay.saturday.rawValue {
-                let tempDistanceBetweenWeekDay = weekDay - currentWeekDay
-                distancesBetweenWeekDay.append(tempDistanceBetweenWeekDay)
-            }
-            
-            let sundayWeekDay = 8
-            distancesBetweenWeekDay.append(sundayWeekDay - currentWeekDay)
-        }
-        
-        distancesBetweenWeekDay.forEach { distance in
-            guard let calculatedDate = Calendar.koreaISO8601.date(byAdding: .day, value: distance, to: self.normalizedCurrent) else { return }
-            datesIncludedWeek.append(calculatedDate)
-        }
-        
-        return datesIncludedWeek
+        self.datesIncludedInWeek(fromDate: .normalizedCurrent)
     }
     
     static var thursdayOfThisWeek: Date {
@@ -121,6 +99,33 @@ extension Date {
     static func convertWeekNoToString(weekNo: Int) -> String? {
         let weekDict = [1: "첫째주", 2: "둘째주", 3: "셋째주", 4: "넷째주", 5: "다섯째주"]
         return weekDict[weekNo]
+    }
+    
+    static func datesIncludedInWeek(fromDate date: Date) -> [Date] {
+        let normalizedDate = date.normalizedDate ?? date
+        let weekDay = Calendar.koreaISO8601.component(.weekday, from: normalizedDate)
+        
+        var datesIncludedWeek: [Date]      = []
+        var distancesBetweenWeekDay: [Int] = []
+        
+        if weekDay == WeekDay.sunday.rawValue {
+            distancesBetweenWeekDay = [-6, -5, -4, -3, -2, -1, 0] }
+        else {
+            for weekDayValue in WeekDay.monday.rawValue...WeekDay.saturday.rawValue {
+                let tempDistanceBetweenWeekDay = weekDayValue - weekDay
+                distancesBetweenWeekDay.append(tempDistanceBetweenWeekDay)
+            }
+            
+            let sundayWeekDay = 8
+            distancesBetweenWeekDay.append(sundayWeekDay - weekDay)
+        }
+        
+        distancesBetweenWeekDay.forEach { distance in
+            guard let calculatedDate = Calendar.koreaISO8601.date(byAdding: .day, value: distance, to: normalizedDate) else { return }
+            datesIncludedWeek.append(calculatedDate)
+        }
+        
+        return datesIncludedWeek
     }
     
     func convertToString(using format: String = "yyyy-MM-dd") -> String {

--- a/polaris-ios/polaris-ios/Sources/Model/Journey/JourneyTitleListModel.swift
+++ b/polaris-ios/polaris-ios/Sources/Model/Journey/JourneyTitleListModel.swift
@@ -14,4 +14,20 @@ struct JourneyTitleModel: Codable {
     let month: Int?
     let weekNo: Int?
     let userIdx: Int?
+    
+    init(
+        idx: Int?,
+        title: String?,
+        year: Int?,
+        month: Int?,
+        weekNo: Int?,
+        userIdx: Int?
+    ) {
+        self.idx = idx
+        self.title = title
+        self.year = year
+        self.month = month
+        self.weekNo = weekNo
+        self.userIdx = userIdx
+    }
 }

--- a/polaris-ios/polaris-ios/Sources/Model/Journey/JourneyWeekListModel.swift
+++ b/polaris-ios/polaris-ios/Sources/Model/Journey/JourneyWeekListModel.swift
@@ -22,7 +22,7 @@ struct WeekJourneyModel: Codable {
     let year, month, weekNo: Int?
     let userIdx: Int?
     let value1, value2: String?
-    let toDos: [TodoModel]?
+    var toDos: [TodoModel]?
 }
 
 extension WeekJourneyModel: TodoSectionHeaderPresentable {
@@ -35,6 +35,17 @@ extension WeekJourneyModel: TodoSectionHeaderPresentable {
     var secondValueJourney: Journey? {
         guard let value = self.value2 else { return nil }
         return Journey(rawValue: value)
+    }
+    
+    var journeyTitleModel: JourneyTitleModel {
+        JourneyTitleModel(
+            idx: self.idx,
+            title: self.title,
+            year: self.year,
+            month: self.month,
+            weekNo: self.weekNo,
+            userIdx: self.userIdx
+        )
     }
     
 }

--- a/polaris-ios/polaris-ios/Sources/Model/TodoList/TodoDayListModel.swift
+++ b/polaris-ios/polaris-ios/Sources/Model/TodoList/TodoDayListModel.swift
@@ -23,7 +23,7 @@ struct TodoModel: Codable {
     var isDone: String?
     let date: String?
     let createdAt: String?
-    let journey: JourneyTitleModel?
+    var journey: JourneyTitleModel?
 }
 
 extension TodoModel {

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/CollectionViewCell/PerDayItemCollectionViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/CollectionViewCell/PerDayItemCollectionViewCell.swift
@@ -9,7 +9,9 @@ import UIKit
 
 class PerDayItemCollectionViewCell: UICollectionViewCell {
     
-    override var isSelected: Bool { didSet { self.update(by: self.isSelected) } }
+    override var isSelected: Bool {
+        didSet { self.update(by: self.isSelected) }
+    }
     
     @IBOutlet weak var dayLabel: UILabel!
     @IBOutlet weak var dayNumberLabel: UILabel!

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoDayTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoDayTableViewCell.swift
@@ -39,6 +39,9 @@ class AddTodoDayTableViewCell: AddTodoTableViewCell {
         case .editTodo(let todo):
             self.viewModel.occur(viewEvent: .configureForEdit(todo))
             
+        case .addJourneyTodo(let journey):
+            self.viewModel.occur(viewEvent: .configureForAddJourneyTodo(journey))
+            
         default:
             break
         }

--- a/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoDayTableViewCell.swift
+++ b/polaris-ios/polaris-ios/Sources/Storyboard/View/TableViewCell/AddTodoDayTableViewCell.swift
@@ -37,19 +37,11 @@ class AddTodoDayTableViewCell: AddTodoTableViewCell {
         
         switch addMode {
         case .editTodo(let todo):
-            guard let todoDate = todo.date?.convertToDate()?.normalizedDate else { return }
-            self.updateSelectDate(todoDate)
+            self.viewModel.occur(viewEvent: .configureForEdit(todo))
             
         default:
             break
         }
-    }
-    
-    private func updateSelectDate(_ date: Date) {
-        guard let selectedDateIndex = self.viewModel.datesRelay.value.firstIndex(of: date) else { return }
-        let indexPath = IndexPath(item: selectedDateIndex, section: 0)
-        self.collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
-        self.viewModel.selectedDateSubject.onNext(date)
     }
     
     // MARK: - Set Up
@@ -69,30 +61,41 @@ class AddTodoDayTableViewCell: AddTodoTableViewCell {
     
     // MARK: - Bind
     private func bindCollectionView() {
-        self.viewModel.datesRelay.bind(to: self.collectionView.rx.items) { collectionView, index, item in
+        self.viewModel.datesObservable.bind(to: self.collectionView.rx.items) { collectionView, index, item in
             let indexPath = IndexPath(item: index, section: 0)
-            let cell      = collectionView.dequeueReusableCell(cell: PerDayItemCollectionViewCell.self, forIndexPath: indexPath)
+            let cell = collectionView.dequeueReusableCell(
+                cell: PerDayItemCollectionViewCell.self,
+                forIndexPath: indexPath
+            )
             
             guard let perDayCell = cell else { return UICollectionViewCell() }
             perDayCell.configure(item)
             return perDayCell
         }.disposed(by: self.disposeBag)
         
-        self.collectionView.rx.itemSelected
-            .subscribe(onNext: { [weak self] indexPath in
-                guard let self = self else { return }
-                guard let selectedDate = self.viewModel.datesRelay.value[safe: indexPath.row] else { return }
-                self.viewModel.selectedDateSubject.onNext(selectedDate)
+        self.viewModel.selectedDateObservable
+            .withUnretained(self)
+            .observeOnMain(onNext: { owner, selectedDate in
+                guard let selectedDate = selectedDate else { return }
+                
+                owner.updateSelectedDateCell(selectedDate)
+                owner._delegate?.addTodoDayTableViewCell(owner, didSelectDate: selectedDate)
             })
             .disposed(by: self.disposeBag)
         
-        self.viewModel.selectedDateSubject
-            .subscribe(onNext: { [weak self] selectedDate in
-                guard let self = self                 else { return }
-                guard let selectedDate = selectedDate else { return }
-                
-                self._delegate?.addTodoDayTableViewCell(self, didSelectDate: selectedDate)
-            }).disposed(by: self.disposeBag)
+        self.collectionView.rx.itemSelected
+            .withUnretained(self)
+            .subscribe(onNext: { owner, indexPath in
+                owner.viewModel.occur(viewEvent: .selectCollectionView(indexPath: indexPath))
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
+    private func updateSelectedDateCell(_ selectedDate: Date) {
+        guard let selectedIndex = self.viewModel.dates.firstIndex(of: selectedDate) else { return }
+        
+        let selectedIndexPath = IndexPath(item: selectedIndex, section: 0)
+        self.collectionView.selectItem(at: selectedIndexPath, animated: false, scrollPosition: [])
     }
     
     private weak var _delegate: AddTodoDayTableViewCellDelegate?

--- a/polaris-ios/polaris-ios/Sources/TodoList/Controller/TodoController.swift
+++ b/polaris-ios/polaris-ios/Sources/TodoList/Controller/TodoController.swift
@@ -41,6 +41,24 @@ final class TodoController {
     func fetchTodoJourneyList(ofDate date: PolarisDate) -> Observable<[WeekJourneyModel]> {
         self.todoRepository.fetchTodoJourneyList(ofDate: date)
             .map { $0.data }
+            .map { journeySections in
+                var newJourenySections = [WeekJourneyModel]()
+                
+                for index in 0..<journeySections.count {
+                    guard var section = journeySections[safe: index] else { continue }
+                    
+                    let journeyTitleModel = section.journeyTitleModel
+                    let newTodos = section.toDos?.map { todo -> TodoModel in
+                        var todo = todo
+                        todo.journey = journeyTitleModel
+                        return todo
+                    }
+                    
+                    section.toDos = newTodos
+                    newJourenySections.append(section)
+                }
+                return newJourenySections
+            }
             .do(onNext: { [weak self] journeySections in
                 self?.journeySections = journeySections
             })

--- a/polaris-ios/polaris-ios/Sources/ViewModel/AddTodo/AddTodoDayViewModel.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewModel/AddTodo/AddTodoDayViewModel.swift
@@ -28,6 +28,9 @@ class AddTodoDayViewModel {
         case .configureForEdit(let todo):
             self.prepareDatesForEdit(todo: todo)
             
+        case .configureForAddJourneyTodo(let journey):
+            self.prepareDatesForAddJourneyTodo(journey: journey)
+            
         case .selectCollectionView(let indexPath):
             self.selectDate(ofIndexPath: indexPath)
         
@@ -45,6 +48,12 @@ class AddTodoDayViewModel {
         self.selectDate(ofIndexPath: todoDateIndexPath)
     }
     
+    private func prepareDatesForAddJourneyTodo(journey: WeekJourneyModel) {
+        let polarisDate = PolarisDate(year: journey.year ?? 0, month: journey.month ?? 0, weekNo: journey.weekNo ?? 0)
+        let weekDates = Date.datesIncludedInWeek(fromPolarisDate: polarisDate)
+        self.datesRelay.accept(weekDates)
+    }
+    
     private func updateDates(fromTodo todo: TodoModel) {
         guard let todoDate = todo.date?.convertToDate()?.normalizedDate else { return }
         
@@ -57,10 +66,6 @@ class AddTodoDayViewModel {
         self.selectedDateRelay.accept(selectedDate)
     }
     
-    private func selectDate(ofTodo todo: TodoModel) {
-        
-    }
-    
     private let selectedDateRelay = BehaviorRelay<Date?>(value: nil)
     private let datesRelay = BehaviorRelay<[Date]>(value: Date.datesIncludedThisWeek)
     
@@ -70,6 +75,7 @@ extension AddTodoDayViewModel {
     
     enum ViewEvent {
         case configureForEdit(TodoModel)
+        case configureForAddJourneyTodo(WeekJourneyModel)
         case selectCollectionView(indexPath: IndexPath)
     }
     

--- a/polaris-ios/polaris-ios/Sources/ViewModel/AddTodo/AddTodoDayViewModel.swift
+++ b/polaris-ios/polaris-ios/Sources/ViewModel/AddTodo/AddTodoDayViewModel.swift
@@ -11,7 +11,66 @@ import RxRelay
 
 class AddTodoDayViewModel {
     
-    let datesRelay        = BehaviorRelay<[Date]>(value: Date.datesIncludedThisWeek)
-    let selectedDateSubject = BehaviorSubject<Date?>(value: nil)
+    var dates: [Date] {
+        self.datesRelay.value
+    }
+    
+    var datesObservable: Observable<[Date]> {
+        self.datesRelay.asObservable()
+    }
+    
+    var selectedDateObservable: Observable<Date?> {
+        self.selectedDateRelay.asObservable()
+    }
+    
+    func occur(viewEvent: ViewEvent) {
+        switch viewEvent {
+        case .configureForEdit(let todo):
+            self.prepareDatesForEdit(todo: todo)
+            
+        case .selectCollectionView(let indexPath):
+            self.selectDate(ofIndexPath: indexPath)
+        
+        }
+    }
+    
+    private func prepareDatesForEdit(todo: TodoModel) {
+        guard let todoDate = todo.date?.convertToDate()?.normalizedDate else { return }
+
+        let weekDates = Date.datesIncludedInWeek(fromDate: todoDate)
+        self.datesRelay.accept(weekDates)
+        
+        guard let todoDateIndex = weekDates.firstIndex(of: todoDate) else { return }
+        let todoDateIndexPath = IndexPath(item: todoDateIndex, section: 0)
+        self.selectDate(ofIndexPath: todoDateIndexPath)
+    }
+    
+    private func updateDates(fromTodo todo: TodoModel) {
+        guard let todoDate = todo.date?.convertToDate()?.normalizedDate else { return }
+        
+        let weekDates = Date.datesIncludedInWeek(fromDate: todoDate)
+        self.datesRelay.accept(weekDates)
+    }
+    
+    private func selectDate(ofIndexPath indexPath: IndexPath) {
+        guard let selectedDate = self.dates[safe: indexPath.row] else { return }
+        self.selectedDateRelay.accept(selectedDate)
+    }
+    
+    private func selectDate(ofTodo todo: TodoModel) {
+        
+    }
+    
+    private let selectedDateRelay = BehaviorRelay<Date?>(value: nil)
+    private let datesRelay = BehaviorRelay<[Date]>(value: Date.datesIncludedThisWeek)
+    
+}
+
+extension AddTodoDayViewModel {
+    
+    enum ViewEvent {
+        case configureForEdit(TodoModel)
+        case selectCollectionView(indexPath: IndexPath)
+    }
     
 }


### PR DESCRIPTION
### PR 내용

* 여정별 할일에서 할 일 추가 및 수정 시, 날짜 선택 부분 수정
    * as-is
        * 이전에는 할일이 이번주만 보여줄 수 있어서, 이번주를 기준으로 7일만 선택할 수 있게 되어 있었음

    * to-be
        * 다른 주차의 할일 및 여정이 보여지면서 여정별 할일에서 할 일 추가 및 수정 시, 선택된 주차의 날짜 7일을 보여줄 수 있게 수정

* 여정별 할 일은 `TodoModel`의 journey 부분이 nil로 내려와서 상위 모델에서 채워줄 수 있게 수정

### 이슈 번호
* #47 